### PR TITLE
Payload submission can result in a spooler error

### DIFF
--- a/apps/cvmfs_gateway/src/cvmfs_receiver.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_receiver.erl
@@ -46,6 +46,7 @@
                              worker_died |
                              worker_timeout |
                              path_violation |
+                             spooler_error |
                              other_error}.
 -type submit_payload_result() :: {ok, payload_added} |
                                  {ok, payload_added, lease_ended} |
@@ -375,6 +376,8 @@ p_submit_payload({LeaseToken, Payload, Digest, HeaderSize}, Secret, WorkerPort, 
                                     {ok, payload_added};
                                 #{<<"status">> := <<"error">>, <<"reason">> := <<"path_violation">>} ->
                                     {error, path_violation};
+                                #{<<"status">> := <<"error">>, <<"reason">> := <<"spooler_error">>} ->
+                                    {error, spooler_error};
                                 #{<<"status">> := <<"error">>, <<"reason">> := <<"other_error">>} ->
                                     {error, other_error}
                             end;


### PR DESCRIPTION
The spooler object used by the cvmfs_receiver to upload objects into the
repository can encounter an error, and the client should be notified.