### PR TITLE
Package version should include nightly build number

### DIFF
--- a/ci/make_package.sh
+++ b/ci/make_package.sh
@@ -10,6 +10,15 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+if [ -z $BUILD_NUMBER ]; then
+  echo "BUILD_NUMBER not defined"
+  exit 2
+fi
+if [ -z $CVMFS_NIGHTLY_BUILD ]; then
+  echo "CVMFS_NIGHTLY_BUILD not defined"
+  exit 2
+fi
+
 CVMFS_BUILD_LOCATION="$1"
 shift 1
 
@@ -25,17 +34,22 @@ REPO_GATEWAY_VERSION=$(grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" apps/cvmfs_gateway/sr
 TARBALL_NAME=cvmfs-gateway_${REPO_GATEWAY_VERSION}_${CVMFS_BUILD_PLATFORM}_x86_64.tar.gz
 PKGMAP_FILE=${CVMFS_BUILD_LOCATION}/pkgmap/pkgmap.${CVMFS_BUILD_PLATFORM}_x86_64
 
+PACKAGE_VERSION=1
+if [ x"$CVMFS_NIGHTLY_BUILD" = x"true" ]; then
+    PACKAGE_VERSION=0.$BUILD_NUMBER
+fi
+
 # Create an RPM or DEB package from the tarball
 if [ x"${CVMFS_BUILD_PLATFORM}" = xubuntu1604 ]; then
     PACKAGE_TYPE=deb
     PACKAGE_NAME_SUFFIX="+ubuntu16.04_amd64"
     PACKAGE_LOCATION=DEBS
-    PACKAGE_NAME=cvmfs-gateway_${REPO_GATEWAY_VERSION}~1${PACKAGE_NAME_SUFFIX}.${PACKAGE_TYPE}
+    PACKAGE_NAME=cvmfs-gateway_${REPO_GATEWAY_VERSION}~${PACKAGE_VERSION}${PACKAGE_NAME_SUFFIX}.${PACKAGE_TYPE}
 elif [ x"${CVMFS_BUILD_PLATFORM}" = xslc6 ] || [ x"${CVMFS_BUILD_PLATFORM}" = xcc7 ]; then
     PACKAGE_TYPE=rpm
     PACKAGE_NAME_SUFFIX="$(rpm --eval "%{?dist}").x86_64"
     PACKAGE_LOCATION=RPMS
-    PACKAGE_NAME=cvmfs-gateway-${REPO_GATEWAY_VERSION}-1${PACKAGE_NAME_SUFFIX}.${PACKAGE_TYPE}
+    PACKAGE_NAME=cvmfs-gateway-${REPO_GATEWAY_VERSION}-${PACKAGE_VERSION}${PACKAGE_NAME_SUFFIX}.${PACKAGE_TYPE}
 fi
 
 mkdir -p ${CVMFS_BUILD_LOCATION}/$PACKAGE_LOCATION


### PR DESCRIPTION
Adopting the same numbering scheme as for the main CVMFS packages.