### PR TITLE
Ensure that lease creation/cancellation requests are serviced immediately

### DIFF
--- a/apps/cvmfs_gateway/src/cvmfs_gateway.app.src
+++ b/apps/cvmfs_gateway/src/cvmfs_gateway.app.src
@@ -1,7 +1,7 @@
 {application, cvmfs_gateway,
  [{description, "CVMFS Repository Gateway"},
   {vsn, "0.3.0"},
-  {registered, [cvmfs_auth, cvmfs_be, cvmfs_commit_sup, cvmfs_fe, cvmfs_lease, cvmfs_receiver_pool]},
+  {registered, [cvmfs_auth, cvmfs_be, cvmfs_commit_sup, cvmfs_fe, cvmfs_lease, cvmfs_receiver_pool, cvmfs_fast_receiver_pool]},
   {mod, {cvmfs_gateway_app, []}},
   {applications,
    [kernel,

--- a/apps/cvmfs_gateway/src/cvmfs_gateway_sup.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_gateway_sup.erl
@@ -37,7 +37,7 @@ init({EnabledWorkers, Repos, Keys, PoolConfig, WorkerConfig}) ->
     ReceiverPoolConfig = [{name, {local, cvmfs_receiver_pool}} | PoolConfig],
     FastReceiverPoolConfig = [{name,
                                {local, cvmfs_fast_receiver_pool}} |
-                              maps:put(size, 1, PoolConfig)],
+                              lists:keystore(size, 1, PoolConfig, {size, 1})],
     WorkerSpecs = #{
       cvmfs_auth => #{id => cvmfs_auth,
                       start => {cvmfs_auth, start_link, [{Repos, Keys}]},

--- a/apps/cvmfs_gateway/src/cvmfs_gateway_sup.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_gateway_sup.erl
@@ -35,6 +35,9 @@ init({EnabledWorkers, Repos, Keys, PoolConfig, WorkerConfig}) ->
                         intensity => 5,
                         period => 5},
     ReceiverPoolConfig = [{name, {local, cvmfs_receiver_pool}} | PoolConfig],
+    FastReceiverPoolConfig = [{name,
+                               {local, cvmfs_fast_receiver_pool}} |
+                              maps:put(size, 1, PoolConfig)],
     WorkerSpecs = #{
       cvmfs_auth => #{id => cvmfs_auth,
                       start => {cvmfs_auth, start_link, [{Repos, Keys}]},
@@ -55,6 +58,9 @@ init({EnabledWorkers, Repos, Keys, PoolConfig, WorkerConfig}) ->
                        type => worker,
                        modules => [cvmfs_lease]},
       cvmfs_receiver_pool => poolboy:child_spec(cvmfs_receiver_pool, ReceiverPoolConfig, WorkerConfig),
+      cvmfs_fast_receiver_pool => poolboy:child_spec(cvmfs_fast_receiver_pool,
+                                                     FastReceiverPoolConfig,
+                                                     WorkerConfig),
       cvmfs_commit_sup => #{id => cvmfs_commit_sup,
                             start => {cvmfs_commit_sup, start_link, [Repos]},
                             restart => permanent,

--- a/apps/cvmfs_gateway/src/cvmfs_gateway_sup.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_gateway_sup.erl
@@ -35,6 +35,10 @@ init({EnabledWorkers, Repos, Keys, PoolConfig, WorkerConfig}) ->
                         intensity => 5,
                         period => 5},
     ReceiverPoolConfig = [{name, {local, cvmfs_receiver_pool}} | PoolConfig],
+    %% We create a duplicate of the receiver worker pool configuration, used
+    %% for a second worker pool, which services "fast" requests - generating
+    %% and checking session tokens. For the moment, the size of the pool is
+    %% fixed to 1, since the requests complete almost instantaneously.
     FastReceiverPoolConfig = [{name,
                                {local, cvmfs_fast_receiver_pool}} |
                               lists:keystore(size, 1, PoolConfig, {size, 1})],
@@ -57,6 +61,10 @@ init({EnabledWorkers, Repos, Keys, PoolConfig, WorkerConfig}) ->
                        shutdown => 2000,
                        type => worker,
                        modules => [cvmfs_lease]},
+      %% Two receiver worker pools are created: one for servicing longer requests, like payload
+      %% submission and committing transactions, and another one for fast requests - generating
+      %% and checking session tokens. This ensures that a client requesting a new lease can't
+      %% be blocked when all the workers in the normal pool are servicing long running requests.
       cvmfs_receiver_pool => poolboy:child_spec(cvmfs_receiver_pool, ReceiverPoolConfig, WorkerConfig),
       cvmfs_fast_receiver_pool => poolboy:child_spec(cvmfs_fast_receiver_pool,
                                                      FastReceiverPoolConfig,

--- a/apps/cvmfs_gateway/src/cvmfs_receiver.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_receiver.erl
@@ -307,7 +307,7 @@ code_change(_OldVsn, State, _Extra) ->
                                   Path :: binary(),
                                   MaxLeaseTime :: integer(),
                                   WorkerPort :: port(),
-                                  From :: pid(),
+                                  From :: {pid(), _},
                                   Timeout :: integer(),
                                   Token :: binary(),
                                   Public :: binary(),
@@ -331,7 +331,7 @@ p_generate_token(KeyId, Path, MaxLeaseTime, WorkerPort, From, Timeout) ->
                     -> {ok, PublicId} | {error, invalid_macaroon}
                            when Token :: binary(),
                                 WorkerPort :: port(),
-                                From :: pid(),
+                                From :: {pid(), _},
                                 Timeout :: integer(),
                                 PublicId :: binary().
 p_get_token_id(Token, WorkerPort, From, Timeout) ->
@@ -356,7 +356,7 @@ p_get_token_id(Token, WorkerPort, From, Timeout) ->
                                                     when SubmissionData :: payload_submission_data(),
                                                          Secret :: binary(),
                                                          WorkerPort :: port(),
-                                                         From :: pid(),
+                                                         From :: {pid(), _},
                                                          Timeout :: integer().
 p_submit_payload({LeaseToken, Payload, Digest, HeaderSize}, Secret, WorkerPort, From, Timeout) ->
     Req1 = jsx:encode(#{<<"token">> => LeaseToken, <<"secret">> => Secret}),
@@ -405,7 +405,7 @@ p_submit_payload({LeaseToken, Payload, Digest, HeaderSize}, Secret, WorkerPort, 
                                              OldRootHash :: binary(),
                                              NewRootHash :: binary(),
                                              RepoTag :: cvmfs_common_types:repository_tag(),
-                                             From :: pid(),
+                                             From :: {pid(), _},
                                              Timeout :: integer().
 p_commit(WorkerPort, LeasePath, OldRootHash, NewRootHash, RepoTag, From, Timeout) ->
     {TagName, TagChannel, TagDescription} = RepoTag,

--- a/apps/cvmfs_gateway/src/cvmfs_receiver.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_receiver.erl
@@ -81,7 +81,7 @@ start_link(Args) ->
                                                             Public :: binary(),
                                                             Secret :: binary().
 generate_token(KeyId, Path, MaxLeaseTime) ->
-    poolboy:transaction(cvmfs_receiver_pool,
+    poolboy:transaction(cvmfs_fast_receiver_pool,
                         fun(WorkerPid) ->
                                 gen_server:call(WorkerPid,
                                                 {worker_req,
@@ -99,7 +99,7 @@ generate_token(KeyId, Path, MaxLeaseTime) ->
                                  when Token :: binary(),
                                       PublicId :: binary().
 get_token_id(Token) ->
-    poolboy:transaction(cvmfs_receiver_pool,
+    poolboy:transaction(cvmfs_fast_receiver_pool,
                         fun(WorkerPid) ->
                                 gen_server:call(WorkerPid,
                                                 {worker_req,

--- a/apps/cvmfs_gateway/src/cvmfs_receiver.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_receiver.erl
@@ -81,6 +81,7 @@ start_link(Args) ->
                                                             Public :: binary(),
                                                             Secret :: binary().
 generate_token(KeyId, Path, MaxLeaseTime) ->
+    %% The request is sent to the fast worker pool
     poolboy:transaction(cvmfs_fast_receiver_pool,
                         fun(WorkerPid) ->
                                 gen_server:call(WorkerPid,
@@ -99,6 +100,7 @@ generate_token(KeyId, Path, MaxLeaseTime) ->
                                  when Token :: binary(),
                                       PublicId :: binary().
 get_token_id(Token) ->
+    %% The request is sent to the fast worker pool
     poolboy:transaction(cvmfs_fast_receiver_pool,
                         fun(WorkerPid) ->
                                 gen_server:call(WorkerPid,

--- a/apps/cvmfs_gateway/test/cvmfs_be_SUITE.erl
+++ b/apps/cvmfs_gateway/test/cvmfs_be_SUITE.erl
@@ -91,6 +91,7 @@ init_per_suite(Config) ->
                                                                 cvmfs_lease,
                                                                 cvmfs_be,
                                                                 cvmfs_receiver_pool,
+                                                                cvmfs_fast_receiver_pool,
                                                                 cvmfs_commit_sup]),
     ok = application:set_env(cvmfs_gateway, repo_config,
                              cvmfs_test_util:make_test_repo_config()),

--- a/apps/cvmfs_gateway/test/cvmfs_fe_SUITE.erl
+++ b/apps/cvmfs_gateway/test/cvmfs_fe_SUITE.erl
@@ -61,7 +61,8 @@ init_per_suite(Config) ->
                                                                 cvmfs_lease,
                                                                 cvmfs_be,
                                                                 cvmfs_fe,
-                                                                cvmfs_receiver_pool]),
+                                                                cvmfs_receiver_pool,
+                                                                cvmfs_fast_receiver_pool]),
     ok = application:set_env(cvmfs_gateway, repo_config,
                              cvmfs_test_util:make_test_repo_config()),
 

--- a/config/sys.config.dev
+++ b/config/sys.config.dev
@@ -13,6 +13,7 @@
                                        cvmfs_auth,
                                        cvmfs_lease,
                                        cvmfs_receiver_pool,
+                                       cvmfs_fast_receiver_pool,
                                        cvmfs_commit_sup]},
                    {repo_config, {file, "./config/ct_repo.json"}},
                    {user_config, {file, "./config/ct_user.json"}}]}

--- a/config/sys.config.rel
+++ b/config/sys.config.rel
@@ -13,6 +13,7 @@
                                        cvmfs_auth,
                                        cvmfs_lease,
                                        cvmfs_receiver_pool,
+                                       cvmfs_fast_receiver_pool,
                                        cvmfs_commit_sup]},
                    {repo_config, {file, "/etc/cvmfs/gateway/repo.json"}},
                    {user_config, {file, "/etc/cvmfs/gateway/user.json"}}]}


### PR DESCRIPTION
Addresses [CVM-1547](https://sft.its.cern.ch/jira/browse/CVM-1547).

Using two separate worker pools to handle requests, based on the potential length of the requests. Fast requests (generating and checking session tokens), needed for creating and cancelling leases are now serviced separately from other, longer running requests, like payload submission and committing transactions.