### PR TITLE
Fix bug allowing conflicting leases to be acquired

### DIFF
--- a/apps/cvmfs_gateway/src/cvmfs_lease.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_lease.erl
@@ -182,8 +182,10 @@ handle_call({lease_req, get_lease_secret, Public}, _From, State) ->
     {reply, Reply, State};
 handle_call({lease_req, get_lease_path, Public}, _From, State) ->
     Reply = case p_get_lease(Public) of
+                {ok, #lease{path = {Repo, <<>>}}} ->
+                    {ok, Repo};
                 {ok, #lease{path = {Repo, Path}}} ->
-                    {ok, <<Repo/binary, Path/binary>>};
+                    {ok, <<Repo/binary, "/", Path/binary>>};
                 Other ->
                     Other
             end,

--- a/apps/cvmfs_gateway/src/cvmfs_path_util.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_path_util.erl
@@ -9,7 +9,8 @@
 
 -module(cvmfs_path_util).
 
--export([are_overlapping/2]).
+-export([are_overlapping/2
+        ,split_repo_path/1]).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -33,3 +34,13 @@ drop_leading_slash(<<"/",Rest/binary>>) ->
     Rest;
 drop_leading_slash(Path) ->
     Path.
+
+
+-spec split_repo_path(Path :: binary()) -> {Repo :: binary(), Subpath :: binary()}.
+split_repo_path(Path) when is_binary(Path) ->
+    case binary:split(Path, <<"/">>) of
+        [Repo | []] ->
+            {Repo, <<"">>};
+        [Repo, Subpath] ->
+            {Repo, Subpath}
+    end.

--- a/apps/cvmfs_gateway/src/cvmfs_path_util.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_path_util.erl
@@ -21,6 +21,8 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec are_overlapping(Path1 :: binary(), Path2 :: binary()) -> boolean().
+are_overlapping(Path1, Path2) when size(Path1) == 0; size(Path2) == 0 ->
+    true;
 are_overlapping(Path1, Path2) when size(Path1) > 0, size(Path2) > 0 ->
     SplitPath1 = filename:split(drop_leading_slash(Path1)),
     SplitPath2 = filename:split(drop_leading_slash(Path2)),

--- a/ci/travis_main.sh
+++ b/ci/travis_main.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker run --rm -it -v "${PWD}":/mnt radupopescu/erlang-libsodium:20.2 \
+docker run --rm -it -v "${PWD}":/mnt radupopescu/erlang-libsodium:21 \
        sh -c "cd /mnt && rebar3 release && rebar3 as test dialyzer,ct && rebar3 as prod tar"


### PR DESCRIPTION
Addresses [CVM-1642](https://sft.its.cern.ch/jira/browse/CVM-1642).

Fixes a bug which allowed acquiring conflicting leases, when one path was below the other (i.e. `/a` and `/a/b`).