### PR TITLE
Update RPM packaging script

### DIFF
--- a/ci/make_rpm.sh
+++ b/ci/make_rpm.sh
@@ -69,6 +69,7 @@ togo file flag config-nr root/etc/cvmfs/gateway/user.json
 
 # Mnesia db location
 mkdir -p root/var/lib/cvmfs-gateway
+togo file exclude root/var/lib
 
 # Copy spec file fragments into place
 echo "Copying RPM spec file fragments"

--- a/ci/make_rpm.sh
+++ b/ci/make_rpm.sh
@@ -55,7 +55,7 @@ if [ "x$PLATFORM" = "xcc7" ]; then
 else
     mkdir -p root/etc/init.d
     togo file exclude root/etc/init.d
-    cp -v root/user/libexec/cvmfs-gateway/scripts/cvmfs-gateway.initd \
+    cp -v root/usr/libexec/cvmfs-gateway/scripts/cvmfs-gateway.initd \
           root/etc/init.d/cvmfs-gateway
     togo file flag config-nr root/etc/init.d/cvmfs-gateway
 

--- a/ci/make_rpm.sh
+++ b/ci/make_rpm.sh
@@ -67,6 +67,8 @@ cp -v root/usr/libexec/cvmfs-gateway/etc/user.json root/etc/cvmfs/gateway/
 togo file flag config-nr root/etc/cvmfs/gateway/repo.json
 togo file flag config-nr root/etc/cvmfs/gateway/user.json
 
+# Mnesia db location
+mkdir -p root/var/lib/cvmfs-gateway
 
 # Copy spec file fragments into place
 echo "Copying RPM spec file fragments"

--- a/ci/make_rpm.sh
+++ b/ci/make_rpm.sh
@@ -31,6 +31,43 @@ tar xf $BUILD_LOCATION/$TARBALL
 cd $BUILD_LOCATION/togo/cvmfs-gateway
 togo file exclude root/usr/libexec
 
+# Place and flag config files in the togo workspace
+
+# systemlog configuration
+mkdir -p root/etc/{rsyslog.d,logrotate.d}
+togo file exclude root/etc/rsyslog.d
+togo file exclude root/etc/logrotate.d
+cp -v root/usr/libexec/cvmfs-gateway/scripts/90-cvmfs-gateway.conf \
+      root/etc/rsyslog.d
+togo file flag config-nr root/etc/rsyslog.d/90-cvmfs-gateway.conf
+
+# CentOS 7 uses systemd
+if [ "x$PLATFORM" = "xcc7" ]; then
+    mkdir -p root/etc/systemd/system
+    togo file exclude root/etc/systemd/system
+    cp -v root/usr/libexec/cvmfs-gateway/scripts/cvmfs-gateway.service \
+          root/etc/systemd/system/
+    togo file flag config-nr root/etc/systemd/system/cvmfs-gateway.service
+
+    cp -v root/usr/libexec/cvmfs-gateway/scripts/90-cvmfs-gateway-rotate-systemd \
+        root/etc/logrotate.d
+    togo file flag config-nr root/etc/logrotate.d/90-cvmfs-gateway-rotate-systemd
+else
+    cp -v root/usr/libexec/cvmfs-gateway/scripts/90-cvmfs-gateway-rotate \
+        root/etc/logrotate.d
+    togo file flag config-nr root/etc/logrotate.d/90-cvmfs-gateway-rotate
+fi
+
+# cvmfs-gateway configuration files
+mkdir -p root/etc/cvmfs/gateway
+togo file exclude root/etc
+togo file exclude root/etc/cvmfs
+cp -v root/usr/libexec/cvmfs-gateway/etc/repo.json root/etc/cvmfs/gateway/
+cp -v root/usr/libexec/cvmfs-gateway/etc/user.json root/etc/cvmfs/gateway/
+togo file flag config-nr root/etc/cvmfs/gateway/repo.json
+togo file flag config-nr root/etc/cvmfs/gateway/user.json
+
+
 # Copy spec file fragments into place
 echo "Copying RPM spec file fragments"
 cp -v $SCRIPT_LOCATION/spec/* ./spec/

--- a/ci/make_rpm.sh
+++ b/ci/make_rpm.sh
@@ -53,6 +53,12 @@ if [ "x$PLATFORM" = "xcc7" ]; then
         root/etc/logrotate.d
     togo file flag config-nr root/etc/logrotate.d/90-cvmfs-gateway-rotate-systemd
 else
+    mkdir -p root/etc/init.d
+    togo file exclude root/etc/init.d
+    cp -v root/user/libexec/cvmfs-gateway/scripts/cvmfs-gateway.initd \
+          root/etc/init.d/cvmfs-gateway
+    togo file flag config-nr root/etc/init.d/cvmfs-gateway
+
     cp -v root/usr/libexec/cvmfs-gateway/scripts/90-cvmfs-gateway-rotate \
         root/etc/logrotate.d
     togo file flag config-nr root/etc/logrotate.d/90-cvmfs-gateway-rotate

--- a/ci/spec/header
+++ b/ci/spec/header
@@ -35,7 +35,7 @@ Source0: %{name}.tar
 
 # If this package has prerequisites, uncomment this line and
 #  list them here - examples are already listed
-#Requires: bash, python >= 2.7
+Requires: cvmfs-server
 
 # A more verbose description of your package
 %description

--- a/ci/spec/header
+++ b/ci/spec/header
@@ -35,7 +35,7 @@ Source0: %{name}.tar
 
 # If this package has prerequisites, uncomment this line and
 #  list them here - examples are already listed
-Requires: cvmfs-server
+Requires: cvmfs-server >= 2.5.1
 
 # A more verbose description of your package
 %description

--- a/ci/spec/post
+++ b/ci/spec/post
@@ -1,37 +1,16 @@
 %post
 
-export RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner
-
-# Install syslog configuration file
-echo "Installing the syslog configuration file"
-cp -v /usr/libexec/cvmfs-gateway/scripts/90-cvmfs-gateway.conf /etc/rsyslog.d/
+export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
 
 if [ x"$(which systemctl)" != x"" ]; then
     echo "  - restarting rsyslog"
-    cp -v /usr/libexec/cvmfs-gateway/scripts/90-cvmfs-gateway-rotate-systemd /etc/logrotate.d/
     systemctl restart rsyslog
 
     echo "  - installing systemd service file"
-    cp -v /usr/libexec/cvmfs-gateway/scripts/cvmfs-gateway.service /etc/systemd/system/cvmfs-gateway.service
     systemctl daemon-reload
 else
     echo "  - restarting rsyslog"
-    cp -v /usr/libexec/cvmfs-gateway/scripts/90-cvmfs-gateway-rotate /etc/logrotate.d/
     service rsyslog restart
-fi
-
-# Symlink the configuration directory into /etc/cvmfs/gateway
-if [ ! -e /etc/cvmfs/gateway ]; then
-    echo "Creating onfiguration file directory to /etc/cvmfs/gateway"
-    mkdir -p /etc/cvmfs/gateway
-fi
-if [ ! -e /etc/cvmfs/gateway/repo.json ]; then
-    echo "Copying repo.json to /etc/cvmfs/gateway"
-    cp -v /usr/libexec/cvmfs-gateway/etc/repo.json /etc/cvmfs/gateway/
-fi
-if [ ! -e /etc/cvmfs/gateway/user.json ]; then
-    echo "Copying user.json to /etc/cvmfs/gateway"
-    cp -v /usr/libexec/cvmfs-gateway/etc/user.json /etc/cvmfs/gateway/
 fi
 
 # Setup Mnesia

--- a/ci/spec/post
+++ b/ci/spec/post
@@ -3,13 +3,9 @@
 export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
 
 if [ x"$(which systemctl)" != x"" ]; then
-    echo "  - restarting rsyslog"
     systemctl restart rsyslog
-
-    echo "  - installing systemd service file"
     systemctl daemon-reload
 else
-    echo "  - restarting rsyslog"
     service rsyslog restart
 fi
 
@@ -17,7 +13,6 @@ fi
 echo "Setting up the Mnesia"
 
 cvmfs_mnesia_root=/var/lib/cvmfs-gateway
-echo "  - (re)creating schema directory at $cvmfs_mnesia_root"
 rm -rf $cvmfs_mnesia_root && sudo mkdir -p $cvmfs_mnesia_root
 
 echo "  - creating Mnesia schema"

--- a/ci/spec/post
+++ b/ci/spec/post
@@ -10,6 +10,4 @@ else
 fi
 
 # Setup Mnesia
-cvmfs_mnesia_root=/var/lib/cvmfs-gateway
-rm -rf $cvmfs_mnesia_root && sudo mkdir -p $cvmfs_mnesia_root
-/usr/libexec/cvmfs-gateway/bin/cvmfs_gateway escript scripts/setup_mnesia.escript $cvmfs_mnesia_root
+/usr/libexec/cvmfs-gateway/bin/cvmfs_gateway escript scripts/setup_mnesia.escript /var/lib/cvmfs-gateway

--- a/ci/spec/post
+++ b/ci/spec/post
@@ -2,7 +2,7 @@
 
 export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
 
-if [ x"$(which systemctl)" != x"" ]; then
+if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     systemctl restart rsyslog
     systemctl daemon-reload
 else

--- a/ci/spec/post
+++ b/ci/spec/post
@@ -10,4 +10,5 @@ else
 fi
 
 # Setup Mnesia
+rm -rf /var/lib/cvmfs-gateway/*
 /usr/libexec/cvmfs-gateway/bin/cvmfs_gateway escript scripts/setup_mnesia.escript /var/lib/cvmfs-gateway

--- a/ci/spec/post
+++ b/ci/spec/post
@@ -10,10 +10,6 @@ else
 fi
 
 # Setup Mnesia
-echo "Setting up the Mnesia"
-
 cvmfs_mnesia_root=/var/lib/cvmfs-gateway
 rm -rf $cvmfs_mnesia_root && sudo mkdir -p $cvmfs_mnesia_root
-
-echo "  - creating Mnesia schema"
 /usr/libexec/cvmfs-gateway/bin/cvmfs_gateway escript scripts/setup_mnesia.escript $cvmfs_mnesia_root

--- a/ci/spec/postun
+++ b/ci/spec/postun
@@ -2,7 +2,7 @@
 
 export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
 
-if [ x"$(which systemctl)" != x"" ]; then
+if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" != x"" ]; then
     systemctl restart rsyslog
     systemctl daemon-reload
 else

--- a/ci/spec/postun
+++ b/ci/spec/postun
@@ -8,6 +8,3 @@ if [ x"$(which systemctl)" != x"" ]; then
 else
     service rsyslog restart
 fi
-
-# Mnesia
-rm -rf /var/lib/cvmfs-gateway

--- a/ci/spec/postun
+++ b/ci/spec/postun
@@ -1,20 +1,13 @@
 %postun
 
-export RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner
-
-echo "Removing the syslog configuration file"
-rm -fv /etc/rsyslog.d/90-cvmfs-gateway.conf
+export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
 
 if [ x"$(which systemctl)" != x"" ]; then
-    rm -fv /etc/logrotate.d/90-cvmfs-gateway-rotate-systemd
     systemctl restart rsyslog
-
-    rm -fv /etc/systemd/system/cvmfs-gateway.service
     systemctl daemon-reload
 else
-    rm -fv /etc/logrotate.d/90-cvmfs-gateway-rotate
     service rsyslog restart
 fi
 
-# Setup Mnesia
+# Mnesia
 rm -rfv /var/lib/cvmfs-gateway

--- a/ci/spec/postun
+++ b/ci/spec/postun
@@ -10,4 +10,4 @@ else
 fi
 
 # Mnesia
-rm -rfv /var/lib/cvmfs-gateway
+rm -rf /var/lib/cvmfs-gateway

--- a/ci/spec/postun
+++ b/ci/spec/postun
@@ -2,7 +2,7 @@
 
 export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
 
-if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" != x"" ]; then
+if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     systemctl restart rsyslog
     systemctl daemon-reload
 else

--- a/ci/spec/pre
+++ b/ci/spec/pre
@@ -1,6 +1,6 @@
 %pre
 
-if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" != x"" ]; then
+if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     if [ "x$(systemctl list-unit-files | grep cvmfs-gateway)" != "x" ]; then
         systemctl stop cvmfs-gateway
     fi

--- a/ci/spec/pre
+++ b/ci/spec/pre
@@ -1,6 +1,6 @@
 %pre
 
-if [ x"$(which systemctl)" != x"" ]; then
+if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" != x"" ]; then
     if [ "x$(systemctl list-unit-files | grep cvmfs-gateway)" != "x" ]; then
         systemctl stop cvmfs-gateway
     fi

--- a/ci/spec/pre
+++ b/ci/spec/pre
@@ -6,6 +6,6 @@ if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     fi
 else
     if [ -x /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh ]; then
-        /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
+        /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop || true
     fi
 fi

--- a/ci/spec/preun
+++ b/ci/spec/preun
@@ -1,6 +1,6 @@
 %preun
 
-if [ x"$(which systemctl)" != x"" ]; then
+if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" != x"" ]; then
     if [ "x$(systemctl list-unit-files | grep cvmfs-gateway)" != "x" ]; then
         systemctl stop cvmfs-gateway
     fi

--- a/ci/spec/preun
+++ b/ci/spec/preun
@@ -6,6 +6,6 @@ if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     fi
 else
     if [ -x /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh ]; then
-        /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
+        /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop || true
     fi
 fi

--- a/ci/spec/preun
+++ b/ci/spec/preun
@@ -1,6 +1,6 @@
 %preun
 
-if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" != x"" ]; then
+if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     if [ "x$(systemctl list-unit-files | grep cvmfs-gateway)" != "x" ]; then
         systemctl stop cvmfs-gateway
     fi

--- a/ci/spec/preun
+++ b/ci/spec/preun
@@ -1,7 +1,7 @@
 %preun
 
 if [ x"$(which systemctl)" != x"" ]; then
-    if [ "x$(systemctl list-unit-files | greo cvmfs-gateway)" != "x" ]; then
+    if [ "x$(systemctl list-unit-files | grep cvmfs-gateway)" != "x" ]; then
         systemctl stop cvmfs-gateway
     fi
 else

--- a/config/sys.config.rel
+++ b/config/sys.config.rel
@@ -1,5 +1,5 @@
 [
- {lager, [{log_root, "/tmp"},
+ {lager, [{log_root, "/var/log/cvmfs-gateway"},
           {crash_log, "crash.log"},
           {handlers, [{lager_syslog_backend, ["cvmfs_gateway", local1, debug]}]},
           {extra_sinks, [{error_logger_lager_event, [{handlers, [{lager_syslog_backend,

--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,8 @@
                   ,{copy, "./scripts/reload_repo_config.escript", "scripts/reload_repo_config.escript"}
                   ,{copy, "./scripts/setup.sh", "scripts/setup.sh"}
                   ,{copy, "./scripts/setup_mnesia.escript", "scripts/setup_mnesia.escript"}
-                  ,{copy, "./scripts/cvmfs-gateway.service", "scripts/cvmfs-gateway.service"}]}
+                  ,{copy, "./scripts/cvmfs-gateway.service", "scripts/cvmfs-gateway.service"}
+                  ,{copy, "./scripts/cvmfs-gateway.initd", "scripts/cvmfs-gateway.initd"}]}
 
        ,{dev_mode, true}
        ,{include_erts, false}

--- a/scripts/clear_leases.sh
+++ b/scripts/clear_leases.sh
@@ -2,4 +2,4 @@
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
-RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/clear_leases.escript
+RUNNER_LOG_DIR=/var/log/cvmfs-gateway $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/clear_leases.escript

--- a/scripts/cvmfs-gateway.initd
+++ b/scripts/cvmfs-gateway.initd
@@ -1,0 +1,142 @@
+#!/bin/sh
+
+# Part of the CernVM File System
+# See: http://cernvm.cern.ch
+
+### BEGIN INIT INFO
+# Provides:           cvmfs-gateway
+# Required-Start:     $local_fs $network $named
+# Should-Start:       $time
+# Required-Stop:
+# Should-Stop:
+# Default-Start:      3 4 5
+# Default-Stop:       0 1 2 6
+# Short-Description:  Starts the cvmfs-gateway service
+# Description:        The cvmfs-gateway manages concurrent publication sessions to a single CernVM-FS repository
+### END INIT INFO
+
+. /etc/init.d/functions
+
+# Return values acc. to LSB for all commands but status:
+# 0	  - success
+# 1       - generic or unspecified error
+# 2       - invalid or excess argument(s)
+# 3       - unimplemented feature (e.g. "reload")
+# 4       - user had insufficient privileges
+# 5       - program is not installed
+# 6       - program is not configured
+# 7       - program is not running
+# 8--199  - reserved (8--99 LSB, 100--149 distrib, 150--199 appl)
+
+RETVAL=0
+LOCKFILE=/var/lock/subsys/cvmfs-gateway
+
+prog_agent="/usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh"
+
+
+is_root() {
+  [ $(id -u) -eq 0 ] && return 0
+  return 1
+}
+
+
+start() {
+  ! is_root && return 4
+
+  [ -x $prog_agent ] || return 5
+  echo -n $"Starting CernVM-FS Repository Gateway: "
+  $prog_agent start
+  RETVAL=$?
+  if [ $RETVAL -eq 0 ]; then
+    echo_success
+    echo
+    touch ${LOCKFILE}
+  else
+    echo_failure
+    echo
+  fi
+
+  return $RETVAL
+}
+
+
+stop() {
+  [ ! is_root ] && return 4
+
+  echo -n $"Shutting down CernVM-FS Repository Gateway: "
+  $prog_agent stop
+  RETVAL=$?
+  rm -f $PIFDILE
+  echo_success
+  echo
+
+  [ $RETVAL -eq 0 ] && rm -f ${LOCKFILE}
+
+  return $RETVAL
+}
+
+
+reload() {
+  [ ! is_root ] && return 4
+
+  echo -n $"Reloading CernVM-FS Repository Gateway: "
+  $prog_agent reload
+  RETVAL=$?
+  echo_success
+  echo
+
+  return $RETVAL
+}
+
+
+status() {
+
+  echo -n $"CernVM-FS Repository Gateway Status: "
+  $prog_agent status
+  RETVAL=$?
+
+  return $RETVAL
+}
+
+
+case "$1" in
+  start)
+    start
+    RETVAL=$?
+  ;;
+  stop)
+    stop
+    RETVAL=$?
+  ;;
+  restart|try-restart|condrestart)
+    ## Stop the service and regardless of whether it was
+    ## running or not, start it again.
+    #
+    ## Note: try-restart is now part of LSB (as of 1.9).
+    ## RH has a similar command named condrestart.
+    stop
+    start
+    RETVAL=$?
+  ;;
+    reload|force-reload)
+    reload
+    RETVAL=$?
+  ;;
+  status)
+    # Return value is slightly different for the status command:
+    # 0 - service up and running
+    # 1 - service dead, but /var/run/  pid  file exists
+    # 2 - service dead, but /var/lock/ lock file exists
+    # 3 - service not running (unused)
+    # 4 - service status unknown :-(
+    # 5--199 reserved (5--99 LSB, 100--149 distro, 150--199 appl.)
+    status
+    RETVAL=$?
+  ;;
+  *)
+    echo "Usage: $0 {start|stop|status|try-restart|condrestart|restart|force-reload|reload}"
+    RETVAL=3
+  ;;
+esac
+
+exit $RETVAL

--- a/scripts/cvmfs-gateway.initd
+++ b/scripts/cvmfs-gateway.initd
@@ -33,6 +33,8 @@ LOCKFILE=/var/lock/subsys/cvmfs-gateway
 
 prog_agent="/usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh"
 
+# Erlang needs the HOME env var set
+export HOME=/root
 
 is_root() {
   [ $(id -u) -eq 0 ] && return 0

--- a/scripts/cvmfs-gateway.initd
+++ b/scripts/cvmfs-gateway.initd
@@ -29,7 +29,6 @@
 # 8--199  - reserved (8--99 LSB, 100--149 distrib, 150--199 appl)
 
 RETVAL=0
-LOCKFILE=/var/lock/subsys/cvmfs-gateway
 
 prog_agent="/usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh"
 
@@ -52,7 +51,6 @@ start() {
   if [ $RETVAL -eq 0 ]; then
     echo_success
     echo
-    touch ${LOCKFILE}
   else
     echo_failure
     echo
@@ -68,11 +66,8 @@ stop() {
   echo -n $"Shutting down CernVM-FS Repository Gateway: "
   $prog_agent stop
   RETVAL=$?
-  rm -f $PIFDILE
   echo_success
   echo
-
-  [ $RETVAL -eq 0 ] && rm -f ${LOCKFILE}
 
   return $RETVAL
 }

--- a/scripts/get_leases.sh
+++ b/scripts/get_leases.sh
@@ -2,4 +2,4 @@
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
-RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/get_leases.escript
+RUNNER_LOG_DIR=/var/log/cvmfs-gateway $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/get_leases.escript

--- a/scripts/run_cvmfs_gateway.sh
+++ b/scripts/run_cvmfs_gateway.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner
+export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
 
 wait_for_app_start() {
     local reply=$($SCRIPT_LOCATION/../bin/cvmfs_gateway ping | awk {'print $1'})

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@ set -e
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
-export RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner
+export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
 
 # Install syslog configuration file
 echo "Installing the syslog configuration file"

--- a/scripts/setup_mnesia.escript
+++ b/scripts/setup_mnesia.escript
@@ -9,12 +9,10 @@
 %%% -------------------------------------------------------------------
 
 main([MnesiaRootDir]) ->
-    io:format("Node name: ~p.~n", [node()]),
     application:set_env(mnesia, dir, MnesiaRootDir),
-    io:format("Mnesia root dir: ~p.~n", [MnesiaRootDir]),
     case mnesia:create_schema([node()]) of
         ok ->
-            io:format("Mnesia schema created.~n");
+            ok;
         {error, Reason2} ->
             io:format("Mnesia schema could not be created. Reason: ~p.~n", [Reason2]),
             halt(1)


### PR DESCRIPTION
Addresses [CVM-1615](https://sft.its.cern.ch/jira/browse/CVM-1615).

* Fixes some bugs in RPM installation hooks on SLC6
* Makes the RPM installation silent, in the success case
* Config files are installed directly at their final location and are marked "%config(noreplace)"
* Adds an init.d script for SLC6
* RPM now depends on cvmfs-server