### PR TITLE
Fix logging

### DIFF
--- a/ci/spec/post
+++ b/ci/spec/post
@@ -1,6 +1,6 @@
 %post
 
-export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
+export RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner
 
 if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     systemctl restart rsyslog

--- a/ci/spec/postun
+++ b/ci/spec/postun
@@ -1,6 +1,6 @@
 %postun
 
-export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
+export RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner
 
 if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     systemctl restart rsyslog

--- a/config/sys.config.rel
+++ b/config/sys.config.rel
@@ -1,5 +1,5 @@
 [
- {lager, [{log_root, "/var/log/cvmfs-gateway"},
+ {lager, [{log_root, "/tmp"},
           {crash_log, "crash.log"},
           {handlers, [{lager_syslog_backend, ["cvmfs_gateway", local1, debug]}]},
           {extra_sinks, [{error_logger_lager_event, [{handlers, [{lager_syslog_backend,

--- a/scripts/clear_leases.sh
+++ b/scripts/clear_leases.sh
@@ -2,4 +2,4 @@
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
-RUNNER_LOG_DIR=/var/log/cvmfs-gateway $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/clear_leases.escript
+RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/clear_leases.escript

--- a/scripts/get_leases.sh
+++ b/scripts/get_leases.sh
@@ -2,4 +2,4 @@
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
-RUNNER_LOG_DIR=/var/log/cvmfs-gateway $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/get_leases.escript
+RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/get_leases.escript

--- a/scripts/run_cvmfs_gateway.sh
+++ b/scripts/run_cvmfs_gateway.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
+export RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner
 
 wait_for_app_start() {
     local reply=$($SCRIPT_LOCATION/../bin/cvmfs_gateway ping | awk {'print $1'})

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@ set -e
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
-export RUNNER_LOG_DIR=/var/log/cvmfs-gateway
+export RUNNER_LOG_DIR=/var/log/cvmfs-gateway-runner
 
 # Install syslog configuration file
 echo "Installing the syslog configuration file"


### PR DESCRIPTION
Fixes a bug introduced by #65.

`/var/log/cvmfs-gateway` should be reserved for the syslog lager plugin, otherwise the dir permissions will prevent the plugin from writing there.