### PR TITLE
Fixing bug in lease path encoding

### DIFF
--- a/apps/cvmfs_gateway/src/cvmfs_lease.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_lease.erl
@@ -183,7 +183,7 @@ handle_call({lease_req, get_lease_secret, Public}, _From, State) ->
 handle_call({lease_req, get_lease_path, Public}, _From, State) ->
     Reply = case p_get_lease(Public) of
                 {ok, #lease{path = {Repo, <<>>}}} ->
-                    {ok, Repo};
+                    {ok, <<Repo/binary, "/">>};
                 {ok, #lease{path = {Repo, Path}}} ->
                     {ok, <<Repo/binary, "/", Path/binary>>};
                 Other ->

--- a/apps/cvmfs_gateway/test/cvmfs_lease_SUITE.erl
+++ b/apps/cvmfs_gateway/test/cvmfs_lease_SUITE.erl
@@ -172,7 +172,7 @@ get_lease_path_valid(_Config) ->
     Public = <<"public">>,
     Secret = <<"secret">>,
     ok = cvmfs_lease:request_lease(U, P, Public, Secret),
-    {ok, <<"path">>} = cvmfs_lease:get_lease_path(Public).
+    {ok, <<"path/">>} = cvmfs_lease:get_lease_path(Public).
 
 get_lease_path_expired(Config) ->
     U = <<"user">>,


### PR DESCRIPTION
This fixes a bug introduced in PR #64 which changed the way top level
leases are encoded. This caused the cvmfs_receiver process to discard
file modifications at the top level.