### PR TITLE
cvmfs-gateway systemd service: automatically restart application

### DIFF
--- a/scripts/cvmfs-gateway.service
+++ b/scripts/cvmfs-gateway.service
@@ -7,6 +7,8 @@ Type=forking
 ExecStart=/usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh start
 ExecStop=/usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
 ExecReload=/usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh reload
+Restart=always
+RestartSec=10
 User=root
 
 [Install]


### PR DESCRIPTION
Update the systemd service file such that `cvmfs-gateway` is automatically restarted. 