### PR TITLE
Endpoints for administration tasks

### DIFF
--- a/ci/make_deb.sh
+++ b/ci/make_deb.sh
@@ -54,6 +54,8 @@ for TARGET_PLATFORM in ubuntu1604 ubuntu1804; do
 
     cp -v ${CVMFS_GATEWAY_SOURCES}/pkg/cvmfs-gateway.service \
         $WORKSPACE/etc/systemd/system/
+    cp -v ${CVMFS_GATEWAY_SOURCES}/pkg/cvmfs-gateway@.service \
+        $WORKSPACE/etc/systemd/system/
     cp -v ${CVMFS_GATEWAY_SOURCES}/config/repo.json $WORKSPACE/etc/cvmfs/gateway/
     cp -v ${CVMFS_GATEWAY_SOURCES}/config/user.json $WORKSPACE/etc/cvmfs/gateway/
 
@@ -72,6 +74,7 @@ for TARGET_PLATFORM in ubuntu1604 ubuntu1804; do
         --config-files etc/cvmfs/gateway/repo.json \
         --config-files etc/cvmfs/gateway/user.json \
         --config-files etc/systemd/system/cvmfs-gateway.service \
+        --config-files etc/systemd/system/cvmfs-gateway@.service \
         --exclude etc/systemd/system \
         --no-deb-systemd-restart-after-upgrade \
         --after-install ${CVMFS_GATEWAY_SOURCES}/pkg/setup_deb.sh \

--- a/ci/make_rpm.sh
+++ b/ci/make_rpm.sh
@@ -48,7 +48,10 @@ if [ "x$PLATFORM" = "xcc7" ]; then
     togo file exclude root/etc/systemd/system
     cp -v ${CVMFS_GATEWAY_SOURCES}/pkg/cvmfs-gateway.service \
         ${TOGO_PROJECT}/root/etc/systemd/system/
+    cp -v ${CVMFS_GATEWAY_SOURCES}/pkg/cvmfs-gateway@.service \
+        ${TOGO_PROJECT}/root/etc/systemd/system/
     togo file flag config-nr root/etc/systemd/system/cvmfs-gateway.service
+    togo file flag config-nr root/etc/systemd/system/cvmfs-gateway@.service
 else
     mkdir -p ${TOGO_PROJECT}/root/etc/init.d
     togo file exclude root/etc/init.d

--- a/internal/gateway/backend/access.go
+++ b/internal/gateway/backend/access.go
@@ -74,6 +74,14 @@ func (ae AuthError) Error() string {
 	return fmt.Sprintf("authorization error: %v", ae.Reason)
 }
 
+// RepoBusyError is returned by a repository disable action when the repository is busy
+type RepoBusyError struct {
+}
+
+func (ae RepoBusyError) Error() string {
+	return "repository_busy"
+}
+
 type rawConfig map[string]json.RawMessage
 
 // NewAccessConfig creates an new access configuration from the given file
@@ -119,6 +127,10 @@ func (c *AccessConfig) Check(keyID, leasePath, repoName string) *AuthError {
 	cfg, ok := c.Repositories[repoName]
 	if !ok {
 		return &AuthError{"invalid_repo"}
+	}
+
+	if !cfg.Enabled {
+		return &AuthError{"disabled_repo"}
 	}
 
 	keyPath, ok := cfg.Keys[keyID]

--- a/internal/gateway/backend/access.go
+++ b/internal/gateway/backend/access.go
@@ -82,22 +82,12 @@ func NewAccessConfig(fileName string) (*AccessConfig, error) {
 	return newAccessConfigWithImporter(fileName, keyImporter)
 }
 
-// IsRepositoryEnabled returns true if the repository is enabled
-func (c *AccessConfig) IsRepositoryEnabled(name string) bool {
-	return c.Repositories[name].Enabled
-}
-
 // SetRepositoryEnabled sets the enabled status of a repository
 func (c *AccessConfig) SetRepositoryEnabled(name string, enabled bool) {
 	if cfg, present := c.Repositories[name]; present {
 		cfg.Enabled = enabled
 		c.Repositories[name] = cfg
 	}
-}
-
-// IsKeyEnabled returns true if the repository is enabled
-func (c *AccessConfig) IsKeyEnabled(keyID string) bool {
-	return c.Keys[keyID].Enabled
 }
 
 // SetKeyEnabled sets the enabled status of a key

--- a/internal/gateway/backend/access.go
+++ b/internal/gateway/backend/access.go
@@ -23,9 +23,8 @@ type RepositoryConfig struct {
 
 // KeyConfig contains the secret part and the enabled status of a key
 type KeyConfig struct {
-	Secret  string `json:"secret"`
-	Admin   bool   `json:"admin"`
-	Enabled bool   `json:"enabled"`
+	Secret string `json:"secret"`
+	Admin  bool   `json:"admin"`
 }
 
 // AccessConfig is the configuration of a single repository
@@ -87,14 +86,6 @@ func (c *AccessConfig) SetRepositoryEnabled(name string, enabled bool) {
 	if cfg, present := c.Repositories[name]; present {
 		cfg.Enabled = enabled
 		c.Repositories[name] = cfg
-	}
-}
-
-// SetKeyEnabled sets the enabled status of a key
-func (c *AccessConfig) SetKeyEnabled(keyID string, enabled bool) {
-	if cfg, present := c.Keys[keyID]; present {
-		cfg.Enabled = enabled
-		c.Keys[keyID] = cfg
 	}
 }
 
@@ -201,7 +192,7 @@ func (c *AccessConfig) loadV1(cfg rawConfig, importer KeyImportFun) error {
 				return errors.Wrap(err, fmt.Sprintf("could not import key %v", spec.ID))
 			}
 			keyPaths[keyID] = repoPath
-			c.Keys[keyID] = KeyConfig{Secret: secret, Admin: admin, Enabled: true}
+			c.Keys[keyID] = KeyConfig{Secret: secret, Admin: admin}
 		}
 	}
 
@@ -273,7 +264,7 @@ func (c *AccessConfig) loadV2(cfg rawConfig, importer KeyImportFun) error {
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("could not import key %v", spec.ID))
 			}
-			c.Keys[keyID] = KeyConfig{Secret: secret, Admin: admin, Enabled: true}
+			c.Keys[keyID] = KeyConfig{Secret: secret, Admin: admin}
 		}
 	}
 
@@ -289,7 +280,7 @@ func (c *AccessConfig) loadV2(cfg rawConfig, importer KeyImportFun) error {
 					err, fmt.Sprintf("could not import default key for repository: %v", repoName))
 			}
 			if _, present := c.Keys[keyID]; !present {
-				c.Keys[keyID] = KeyConfig{Secret: secret, Admin: admin, Enabled: true}
+				c.Keys[keyID] = KeyConfig{Secret: secret, Admin: admin}
 			}
 			rc.Keys[keyID] = "/"
 		}

--- a/internal/gateway/backend/access_test.go
+++ b/internal/gateway/backend/access_test.go
@@ -54,7 +54,7 @@ func TestLoadAccessConfigVersion2(t *testing.T) {
 	if len(ac.Repositories) != 2 && len(ac.Keys) != 2 {
 		t.Fatalf("invalid access config (missing items): %+v", ac)
 	}
-	if _, present := (ac.Repositories["test1.repo.org"]["keyid123"]); !present {
+	if _, present := (ac.Repositories["test1.repo.org"].Keys["keyid123"]); !present {
 		t.Fatalf("invalid access config (placeholder was not substituted): %+v", ac)
 	}
 	if _, present := ac.Keys["keyid123"]; !present {
@@ -72,7 +72,7 @@ func TestLoadAccessConfigVersion2NoKeys(t *testing.T) {
 	if len(ac.Repositories) != 1 && len(ac.Keys) != 1 {
 		t.Fatalf("invalid access config (missing items): %+v", ac)
 	}
-	if _, present := (ac.Repositories["test1.repo.org"]["keyid123"]); !present {
+	if _, present := (ac.Repositories["test1.repo.org"].Keys["keyid123"]); !present {
 		t.Fatalf("invalid access config (placeholder was not substituted): %+v", ac)
 	}
 	if _, present := ac.Keys["keyid123"]; !present {

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -31,6 +31,7 @@ type ActionController interface {
 	CancelLease(ctx context.Context, tokenStr string) error
 	CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag) error
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error
+	RunGC(ctx context.Context, options GCOptions) error
 }
 
 // GetKey returns the key configuration associated with a key ID

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -20,9 +20,9 @@ type Services struct {
 
 // ActionController contains the various actions that can be performed with the backend
 type ActionController interface {
-	GetKey(keyID string) *KeyConfig
-	GetRepo(repoName string) *RepositoryConfig
-	GetRepos() map[string]RepositoryConfig
+	GetKey(ctx context.Context, keyID string) *KeyConfig
+	GetRepo(ctx context.Context, repoName string) *RepositoryConfig
+	GetRepos(ctx context.Context) map[string]RepositoryConfig
 	SetRepoEnabled(ctx context.Context, repository string, enabled bool, wait bool) error
 	NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error)
 	GetLeases(ctx context.Context) (map[string]LeaseReturn, error)
@@ -35,7 +35,7 @@ type ActionController interface {
 }
 
 // GetKey returns the key configuration associated with a key ID
-func (s *Services) GetKey(keyID string) *KeyConfig {
+func (s *Services) GetKey(ctx context.Context, keyID string) *KeyConfig {
 	return s.Access.GetKeyConfig(keyID)
 }
 

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -23,6 +23,7 @@ type ActionController interface {
 	GetKey(keyID string) *KeyConfig
 	GetRepo(repoName string) *RepositoryConfig
 	GetRepos() map[string]RepositoryConfig
+	SetRepoEnabled(ctx context.Context, name string, enabled bool, wait bool) error
 	NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error)
 	GetLeases(ctx context.Context) (map[string]LeaseReturn, error)
 	GetLease(ctx context.Context, tokenStr string) (*LeaseReturn, error)

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -21,8 +21,8 @@ type Services struct {
 // ActionController contains the various actions that can be performed with the backend
 type ActionController interface {
 	GetSecret(keyID string) string
-	GetRepo(repoName string) KeyPaths
-	GetRepos() map[string]KeyPaths
+	GetRepo(repoName string) RepositoryConfig
+	GetRepos() map[string]RepositoryConfig
 	NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error)
 	GetLeases(ctx context.Context) (map[string]LeaseReturn, error)
 	GetLease(ctx context.Context, tokenStr string) (*LeaseReturn, error)
@@ -33,7 +33,7 @@ type ActionController interface {
 
 // GetSecret associated with a key ID
 func (s *Services) GetSecret(keyID string) string {
-	return s.Access.GetSecret(keyID)
+	return s.Access.GetKeyConfig(keyID).Secret
 }
 
 // StartBackend initializes the various backend services

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -23,10 +23,11 @@ type ActionController interface {
 	GetKey(keyID string) *KeyConfig
 	GetRepo(repoName string) *RepositoryConfig
 	GetRepos() map[string]RepositoryConfig
-	SetRepoEnabled(ctx context.Context, name string, enabled bool, wait bool) error
+	SetRepoEnabled(ctx context.Context, repository string, enabled bool, wait bool) error
 	NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error)
 	GetLeases(ctx context.Context) (map[string]LeaseReturn, error)
 	GetLease(ctx context.Context, tokenStr string) (*LeaseReturn, error)
+	CancelLeases(ctx context.Context, repoPath string) error
 	CancelLease(ctx context.Context, tokenStr string) error
 	CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag) error
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -20,8 +20,8 @@ type Services struct {
 
 // ActionController contains the various actions that can be performed with the backend
 type ActionController interface {
-	GetSecret(keyID string) string
-	GetRepo(repoName string) RepositoryConfig
+	GetKey(keyID string) *KeyConfig
+	GetRepo(repoName string) *RepositoryConfig
 	GetRepos() map[string]RepositoryConfig
 	NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error)
 	GetLeases(ctx context.Context) (map[string]LeaseReturn, error)
@@ -31,9 +31,9 @@ type ActionController interface {
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error
 }
 
-// GetSecret associated with a key ID
-func (s *Services) GetSecret(keyID string) string {
-	return s.Access.GetKeyConfig(keyID).Secret
+// GetKey returns the key configuration associated with a key ID
+func (s *Services) GetKey(keyID string) *KeyConfig {
+	return s.Access.GetKeyConfig(keyID)
 }
 
 // StartBackend initializes the various backend services

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -31,7 +31,7 @@ type ActionController interface {
 	CancelLease(ctx context.Context, tokenStr string) error
 	CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag) error
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error
-	RunGC(ctx context.Context, options GCOptions) error
+	RunGC(ctx context.Context, options GCOptions) (string, error)
 }
 
 // GetKey returns the key configuration associated with a key ID

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -23,7 +23,7 @@ type ActionController interface {
 	GetKey(ctx context.Context, keyID string) *KeyConfig
 	GetRepo(ctx context.Context, repoName string) *RepositoryConfig
 	GetRepos(ctx context.Context) map[string]RepositoryConfig
-	SetRepoEnabled(ctx context.Context, repository string, enabled bool, wait bool) error
+	SetRepoEnabled(ctx context.Context, repository string, enabled bool) error
 	NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error)
 	GetLeases(ctx context.Context) (map[string]LeaseReturn, error)
 	GetLease(ctx context.Context, tokenStr string) (*LeaseReturn, error)

--- a/internal/gateway/backend/gc_actions.go
+++ b/internal/gateway/backend/gc_actions.go
@@ -1,0 +1,32 @@
+package backend
+
+import (
+	"context"
+	"time"
+)
+
+/*
+gc              [-r number of revisions to preserve]
+[-t time stamp after which revisions are preserved]
+[-l print deleted objects] [-L log of deleted objects]
+[-f force] [-d dry run]
+[-a collect all garbage-collectable repos, log to gc.log |
+  <fully qualified name> ]
+*/
+
+// GCOptions represents the different options supplied for a garbace collection run
+type GCOptions struct {
+	Repository   string    `json:"repo"`
+	NumRevisions int       `json:"num_revisions"`
+	Timestamp    time.Time `json:"timestamp"`
+	Force        bool      `json:"force"`
+	DryRun       bool      `json:"dry_run"`
+	All          bool      `json:"all"`
+	// Verbose is similar to the "-l" parameter, return a list of deleted objects to the caller
+	// Verbose bool `json:"verbose"`
+}
+
+// RunGC triggers garbage collection on the specified repository
+func (s *Services) RunGC(ctx context.Context, options GCOptions) error {
+	return nil
+}

--- a/internal/gateway/backend/lease_actions.go
+++ b/internal/gateway/backend/lease_actions.go
@@ -99,6 +99,21 @@ func (s *Services) GetLease(ctx context.Context, tokenStr string) (*LeaseReturn,
 	return ret, nil
 }
 
+// CancelLeases cancels all the active leases below a repository path
+func (s *Services) CancelLeases(ctx context.Context, repoPath string) error {
+	t0 := time.Now()
+
+	outcome := "success"
+	defer logAction(ctx, "cancel_lease", &outcome, t0)
+
+	if err := s.Leases.CancelLeases(ctx, repoPath); err != nil {
+		outcome = err.Error()
+		return err
+	}
+
+	return nil
+}
+
 // CancelLease associated with the token (transaction rollback)
 func (s *Services) CancelLease(ctx context.Context, tokenStr string) error {
 	t0 := time.Now()

--- a/internal/gateway/backend/leasedb.go
+++ b/internal/gateway/backend/leasedb.go
@@ -72,7 +72,7 @@ type LeaseDB interface {
 	NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int, token LeaseToken) error
 	GetLeases(ctx context.Context) (map[string]Lease, error)
 	GetLease(ctx context.Context, tokenStr string) (string, *Lease, error)
-	CancelLeases(ctx context.Context) error
+	CancelLeases(ctx context.Context, repoPath string) error
 	CancelLease(ctx context.Context, tokenStr string) error
 	WithLock(ctx context.Context, name string, task func() error) error
 }

--- a/internal/gateway/backend/leasedb.go
+++ b/internal/gateway/backend/leasedb.go
@@ -35,6 +35,10 @@ func (e InvalidLeaseError) Error() string {
 	return fmt.Sprintf("invalid lease")
 }
 
+// ErrRepoDisabled signals that a new lease cannot be acquired due to the repository
+// being disabled
+var ErrRepoDisabled = fmt.Errorf("repo_disabled")
+
 // Lease describes an exclusive lease to a subpath inside the repository:
 // keyID and token ()
 type Lease struct {
@@ -75,6 +79,8 @@ type LeaseDB interface {
 	CancelLeases(ctx context.Context, repoPath string) error
 	CancelLease(ctx context.Context, tokenStr string) error
 	WithLock(ctx context.Context, name string, task func() error) error
+	SetRepositoryEnabled(ctx context.Context, repository string, enable bool) error
+	GetRepositoryEnabled(ctx context.Context, repository string) bool
 }
 
 // OpenLeaseDB opens or creats a new LeaseDB object of the specified type

--- a/internal/gateway/backend/leasedb_bolt.go
+++ b/internal/gateway/backend/leasedb_bolt.go
@@ -137,7 +137,7 @@ func (db *BoltLeaseDB) GetLeases(ctx context.Context) (map[string]Lease, error) 
 	err := db.store.View(func(txn *bolt.Tx) error {
 		if err := txn.ForEach(func(name []byte, b *bolt.Bucket) error {
 			bucketName := string(name)
-			if bucketName == "tokens" {
+			if bucketName == "tokens" || bucketName == "disabled_repos" {
 				return nil
 			}
 			if err := b.ForEach(func(k, v []byte) error {

--- a/internal/gateway/backend/leasedb_bolt.go
+++ b/internal/gateway/backend/leasedb_bolt.go
@@ -29,6 +29,10 @@ func OpenBoltLeaseDB(workDir string) (*BoltLeaseDB, error) {
 	}
 
 	store.Update(func(txn *bolt.Tx) error {
+		// Enable all repos
+		if txn.Bucket([]byte("disabled_repos")) != nil {
+			txn.DeleteBucket([]byte("disabled_repos"))
+		}
 		_, err := txn.CreateBucketIfNotExists([]byte("disabled_repos"))
 		if err != nil {
 			return errors.Wrap(err, "could not create bucket: 'disabled_repos'")

--- a/internal/gateway/backend/leasedb_etcd.go
+++ b/internal/gateway/backend/leasedb_etcd.go
@@ -52,3 +52,14 @@ func (db *EtcdLeaseDB) CancelLease(ctx context.Context, tokenStr string) error {
 func (db *EtcdLeaseDB) WithLock(ctx context.Context, repository string, task func() error) error {
 	return nil
 }
+
+// SetRepositoryEnabled sets the enabled/disabled status for a given repository
+func (db *EtcdLeaseDB) SetRepositoryEnabled(
+	ctx context.Context, repository string, enable bool) error {
+	return nil
+}
+
+// GetRepositoryEnabled returns the enabled status of a repository
+func (db *EtcdLeaseDB) GetRepositoryEnabled(ctx context.Context, repository string) bool {
+	return true
+}

--- a/internal/gateway/backend/leasedb_etcd.go
+++ b/internal/gateway/backend/leasedb_etcd.go
@@ -39,7 +39,7 @@ func (db *EtcdLeaseDB) GetLease(ctx context.Context, tokenStr string) (string, *
 }
 
 // CancelLeases cancels all active leases
-func (db *EtcdLeaseDB) CancelLeases(ctx context.Context) error {
+func (db *EtcdLeaseDB) CancelLeases(ctx context.Context, repository string) error {
 	return nil
 }
 

--- a/internal/gateway/backend/leasedb_sqlite.go
+++ b/internal/gateway/backend/leasedb_sqlite.go
@@ -76,6 +76,21 @@ func OpenSqliteLeaseDB(workDir string) (*SqliteLeaseDB, error) {
 		return nil, errors.Wrap(err, "could not prepare statement for 'get disabled repo'")
 	}
 
+	// Enable all repos
+	txn, err := store.Begin()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not begin transaction")
+	}
+	defer txn.Rollback()
+
+	if _, err := txn.Exec("DELETE FROM DisabledRepos;"); err != nil {
+		return nil, errors.Wrap(err, "could not clear DisabledRepos table")
+	}
+
+	if err := txn.Commit(); err != nil {
+		return nil, errors.Wrap(err, "transaction commit failed")
+	}
+
 	gw.Log("leasedb_sqlite", gw.LogInfo).
 		Msgf("database opened (work dir: %v)", workDir)
 

--- a/internal/gateway/backend/leasedb_test.go
+++ b/internal/gateway/backend/leasedb_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestLeaseDBOpen(t *testing.T) {
 	runTest := func(dbType string, t *testing.T) {
-		tmp, err := ioutil.TempDir("", "test_lease_db_" + dbType)
+		tmp, err := ioutil.TempDir("", "test_lease_db_"+dbType)
 		if err != nil {
 			t.Fatalf("could not create temp dir for test case")
 		}
@@ -34,7 +34,7 @@ func TestLeaseDBOpen(t *testing.T) {
 func TestLeaseDBCRUD(t *testing.T) {
 	runTest := func(dbType string, t *testing.T) {
 		lastProtocolVersion := 3
-		tmp, err := ioutil.TempDir("", "test_lease_db_" + dbType)
+		tmp, err := ioutil.TempDir("", "test_lease_db_"+dbType)
 		if err != nil {
 			t.Fatalf("could not create temp dir for test case")
 		}
@@ -83,7 +83,7 @@ func TestLeaseDBCRUD(t *testing.T) {
 			}
 		})
 		t.Run("cancel leases", func(t *testing.T) {
-			err := db.CancelLeases(context.TODO())
+			err := db.CancelLeases(context.TODO(), "repo_name")
 			if err != nil {
 				t.Fatalf("could not cancel all leases")
 			}
@@ -130,7 +130,7 @@ func TestLeaseDBCRUD(t *testing.T) {
 func TestLeaseDBConflicts(t *testing.T) {
 	runTest := func(dbType string, t *testing.T) {
 		lastProtocolVersion := 3
-		tmp, err := ioutil.TempDir("", "test_lease_db_" + dbType)
+		tmp, err := ioutil.TempDir("", "test_lease_db_"+dbType)
 		if err != nil {
 			t.Fatalf("could not create temp dir for test case")
 		}
@@ -186,7 +186,7 @@ func TestLeaseDBConflicts(t *testing.T) {
 func TestLeaseDBExpired(t *testing.T) {
 	runTest := func(dbType string, t *testing.T) {
 		lastProtocolVersion := 3
-		tmp, err := ioutil.TempDir("", "test_lease_db_" + dbType)
+		tmp, err := ioutil.TempDir("", "test_lease_db_"+dbType)
 		if err != nil {
 			t.Fatalf("could not create temp dir for test case")
 		}

--- a/internal/gateway/backend/repo_actions.go
+++ b/internal/gateway/backend/repo_actions.go
@@ -6,19 +6,19 @@ import (
 )
 
 // GetRepo returns the access configuration of a repository
-func (s *Services) GetRepo(repoName string) *RepositoryConfig {
+func (s *Services) GetRepo(ctx context.Context, repoName string) *RepositoryConfig {
 	repo := s.Access.GetRepo(repoName)
 	if repo != nil {
-		repo.Enabled = s.Leases.GetRepositoryEnabled(context.TODO(), repoName)
+		repo.Enabled = s.Leases.GetRepositoryEnabled(ctx, repoName)
 	}
 	return repo
 }
 
 // GetRepos returns a map with repository access configurations
-func (s *Services) GetRepos() map[string]RepositoryConfig {
+func (s *Services) GetRepos(ctx context.Context) map[string]RepositoryConfig {
 	repos := s.Access.GetRepos()
 	for repoName, cfg := range repos {
-		cfg.Enabled = s.Leases.GetRepositoryEnabled(context.TODO(), repoName)
+		cfg.Enabled = s.Leases.GetRepositoryEnabled(ctx, repoName)
 		repos[repoName] = cfg
 	}
 	return repos

--- a/internal/gateway/backend/repo_actions.go
+++ b/internal/gateway/backend/repo_actions.go
@@ -17,7 +17,7 @@ func (s *Services) GetRepos() map[string]RepositoryConfig {
 
 // SetRepoEnabled enables or disables a repository. The change does not persist
 // across applications restarts
-func (s *Services) SetRepoEnabled(ctx context.Context, name string, enable bool, wait bool) error {
+func (s *Services) SetRepoEnabled(ctx context.Context, repository string, enable bool, wait bool) error {
 	t0 := time.Now()
 
 	outcome := "success"
@@ -27,8 +27,8 @@ func (s *Services) SetRepoEnabled(ctx context.Context, name string, enable bool,
 		// If wait == true, the repository is disabled while the global commit lock
 		// of the repository is held
 		if wait {
-			s.Leases.WithLock(ctx, name, func() error {
-				s.Access.SetRepositoryEnabled(name, enable)
+			s.Leases.WithLock(ctx, repository, func() error {
+				s.Access.SetRepositoryEnabled(repository, enable)
 				return nil
 			})
 			return nil
@@ -41,7 +41,7 @@ func (s *Services) SetRepoEnabled(ctx context.Context, name string, enable bool,
 		}
 		busy := false
 		for n := range leases {
-			if n == name {
+			if n == repository {
 				busy = true
 				break
 			}
@@ -52,7 +52,7 @@ func (s *Services) SetRepoEnabled(ctx context.Context, name string, enable bool,
 		}
 	}
 
-	s.Access.SetRepositoryEnabled(name, enable)
+	s.Access.SetRepositoryEnabled(repository, enable)
 
 	return nil
 }

--- a/internal/gateway/backend/repo_actions.go
+++ b/internal/gateway/backend/repo_actions.go
@@ -1,7 +1,7 @@
 package backend
 
 // GetRepo returns the access configuration of a repository
-func (s *Services) GetRepo(repoName string) RepositoryConfig {
+func (s *Services) GetRepo(repoName string) *RepositoryConfig {
 	return s.Access.GetRepo(repoName)
 }
 

--- a/internal/gateway/backend/repo_actions.go
+++ b/internal/gateway/backend/repo_actions.go
@@ -1,11 +1,11 @@
 package backend
 
 // GetRepo returns the access configuration of a repository
-func (s *Services) GetRepo(repoName string) KeyPaths {
+func (s *Services) GetRepo(repoName string) RepositoryConfig {
 	return s.Access.GetRepo(repoName)
 }
 
 // GetRepos returns a map with repository access configurations
-func (s *Services) GetRepos() map[string]KeyPaths {
+func (s *Services) GetRepos() map[string]RepositoryConfig {
 	return s.Access.GetRepos()
 }

--- a/internal/gateway/backend/repo_actions.go
+++ b/internal/gateway/backend/repo_actions.go
@@ -30,7 +30,7 @@ func (s *Services) SetRepoEnabled(ctx context.Context, repository string, enable
 	t0 := time.Now()
 
 	outcome := "success"
-	defer logAction(ctx, "new_lease", &outcome, t0)
+	defer logAction(ctx, "set_repo_enabled", &outcome, t0)
 
 	if !enable {
 		// If wait == true, the repository is disabled while the global commit lock

--- a/internal/gateway/backend/repo_actions_test.go
+++ b/internal/gateway/backend/repo_actions_test.go
@@ -1,0 +1,29 @@
+package backend
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestRepoActionsToggleRepo(t *testing.T) {
+	backend, tmp := StartTestBackend("repo_actions_toggle_test", 1*time.Second)
+	defer func() {
+		backend.Stop()
+		os.RemoveAll(tmp)
+	}()
+
+	repos := backend.GetRepos()
+	repoName := "test1.repo.org"
+	if !repos[repoName].Enabled {
+		t.Fatalf("Repository %v should be enabled by default", repoName)
+	}
+
+	backend.SetRepoEnabled(context.TODO(), repoName, false, false)
+
+	repos = backend.GetRepos()
+	if repos[repoName].Enabled {
+		t.Fatalf("Repository %v should have been disabled", repoName)
+	}
+}

--- a/internal/gateway/backend/repo_actions_test.go
+++ b/internal/gateway/backend/repo_actions_test.go
@@ -14,16 +14,24 @@ func TestRepoActionsToggleRepo(t *testing.T) {
 		os.RemoveAll(tmp)
 	}()
 
-	repos := backend.GetRepos()
+	ctx := context.TODO()
+	repos := backend.GetRepos(ctx)
 	repoName := "test1.repo.org"
 	if !repos[repoName].Enabled {
 		t.Fatalf("Repository %v should be enabled by default", repoName)
 	}
 
-	backend.SetRepoEnabled(context.TODO(), repoName, false, false)
+	backend.SetRepoEnabled(ctx, repoName, false)
 
-	repos = backend.GetRepos()
+	repos = backend.GetRepos(ctx)
 	if repos[repoName].Enabled {
 		t.Fatalf("Repository %v should have been disabled", repoName)
+	}
+
+	backend.SetRepoEnabled(ctx, repoName, true)
+
+	repos = backend.GetRepos(ctx)
+	if !repos[repoName].Enabled {
+		t.Fatalf("Repository %v should have been reenabled", repoName)
 	}
 }

--- a/internal/gateway/backend/testutil.go
+++ b/internal/gateway/backend/testutil.go
@@ -87,14 +87,14 @@ const (
 
 // mockKeyImporter is used by tests, returns a predefined (id, secret) pair
 // instead of reading from file
-func mockKeyImporter(ks KeySpec) (string, string, string, error) {
+func mockKeyImporter(ks KeySpec) (string, string, string, bool, error) {
 	switch ks.KeyType {
 	case "plain_text":
-		return ks.ID, ks.Secret, ks.Path, nil
+		return ks.ID, ks.Secret, ks.Path, ks.Admin, nil
 	case "file":
-		return "keyid123", "secret123", "/", nil
+		return "keyid123", "secret123", "/", false, nil
 	default:
-		return "", "", "", fmt.Errorf("unknown key type")
+		return "", "", "", false, fmt.Errorf("unknown key type")
 	}
 }
 

--- a/internal/gateway/backend/testutil.go
+++ b/internal/gateway/backend/testutil.go
@@ -66,6 +66,12 @@ const accessConfigV2 = `
 			"type": "plain_text",
 			"id": "keyid2",
 			"secret": "secret2"
+		},
+		{
+			"type": "plain_text",
+			"id": "admin0",
+			"secret": "big_secret",
+			"admin": true
 		}
 	]
 }

--- a/internal/gateway/backend/testutil.go
+++ b/internal/gateway/backend/testutil.go
@@ -47,6 +47,7 @@ const accessConfigV2 = `
 			"keys": [
 				{
 					"id": "keyid1",
+					"admin": true,
 					"path": "/"
 				},
 				{

--- a/internal/gateway/frontend/admin_leases.go
+++ b/internal/gateway/frontend/admin_leases.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"net/http"
+	"strings"
 
 	gw "github.com/cvmfs/gateway/internal/gateway"
 	be "github.com/cvmfs/gateway/internal/gateway/backend"
@@ -15,7 +16,7 @@ func MakeAdminLeasesHandler(services be.ActionController) httprouter.Handle {
 
 		msg := map[string]interface{}{"status": "ok"}
 
-		repoPath := ps.ByName("path")
+		repoPath := strings.TrimPrefix(ps.ByName("path"), "/")
 		if repoPath == "" {
 			errMsg := "missing path argument"
 			gw.LogC(ctx, "http", gw.LogError).Msg(errMsg)

--- a/internal/gateway/frontend/admin_leases.go
+++ b/internal/gateway/frontend/admin_leases.go
@@ -1,0 +1,33 @@
+package frontend
+
+import (
+	"net/http"
+
+	gw "github.com/cvmfs/gateway/internal/gateway"
+	be "github.com/cvmfs/gateway/internal/gateway/backend"
+	"github.com/julienschmidt/httprouter"
+)
+
+// MakeAdminLeasesHandler creates an HTTP handler for the API root
+func MakeAdminLeasesHandler(services be.ActionController) httprouter.Handle {
+	return func(w http.ResponseWriter, h *http.Request, ps httprouter.Params) {
+		ctx := h.Context()
+
+		msg := map[string]interface{}{"status": "ok"}
+
+		repoPath := ps.ByName("path")
+		if repoPath == "" {
+			errMsg := "missing path argument"
+			gw.LogC(ctx, "http", gw.LogError).Msg(errMsg)
+			http.Error(w, errMsg, http.StatusBadRequest)
+			return
+		}
+
+		if err := services.CancelLeases(ctx, repoPath); err != nil {
+			msg["status"] = "error"
+			msg["reason"] = err.Error()
+		}
+
+		replyJSON(ctx, w, msg)
+	}
+}

--- a/internal/gateway/frontend/authz.go
+++ b/internal/gateway/frontend/authz.go
@@ -33,7 +33,7 @@ func WithAdminAuthz(ac be.ActionController, next httprouter.Handle) httprouter.H
 			return
 		}
 
-		keyCfg := ac.GetKey(keyID)
+		keyCfg := ac.GetKey(ctx, keyID)
 		if keyCfg == nil {
 			gw.LogC(ctx, "http", gw.LogError).
 				Msg("invalid key ID specified")
@@ -91,7 +91,7 @@ func WithAuthz(ac be.ActionController, next httprouter.Handle) httprouter.Handle
 			return
 		}
 
-		keyCfg := ac.GetKey(keyID)
+		keyCfg := ac.GetKey(ctx, keyID)
 		if keyCfg == nil {
 			gw.LogC(ctx, "http", gw.LogError).
 				Msg("invalid key ID specified")

--- a/internal/gateway/frontend/authz_test.go
+++ b/internal/gateway/frontend/authz_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
@@ -189,4 +190,102 @@ func TestAuthorizationMiddlewareSubmitPayloadNew(t *testing.T) {
 	if !bytes.Equal(msg, respBody) {
 		t.Errorf("Invalid response body: %v", string(respBody))
 	}
+}
+
+func TestAdminAuthorizationMiddleware(t *testing.T) {
+	backend := mockBackend{}
+
+	t.Run("Non-admin key is rejected", func(t *testing.T) {
+		HMAC := ComputeHMAC([]byte("/api/v1/repos/test1.repo.org"), backend.GetKey("keyid2").Secret)
+		req := httptest.NewRequest("DELETE", "/api/v1/repos/test1.repo.org", nil)
+		ps := httprouter.Params{}
+
+		req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
+		w := httptest.NewRecorder()
+		handler := WithAdminAuthz(&backend, forwardBody)
+
+		handler(w, req, ps)
+
+		resp := w.Result()
+
+		if resp.StatusCode != 200 {
+			t.Errorf("Invalid HTTP response status code: %v", resp.StatusCode)
+		}
+
+		respBody, _ := ioutil.ReadAll(resp.Body)
+		if !bytes.Equal([]byte("{\"reason\":\"no_admin_key\",\"status\":\"error\"}"), respBody) {
+			t.Errorf("Invalid response body: %v", string(respBody))
+		}
+	})
+	t.Run("Invalid HTTP method", func(t *testing.T) {
+		HMAC := ComputeHMAC([]byte("/api/v1/repos/test1.repo.org"), backend.GetKey("admin0").Secret)
+		req := httptest.NewRequest("PUT", "/api/v1/repos/test1.repo.org", nil)
+		ps := httprouter.Params{}
+
+		req.Header["Authorization"] = []string{"admin0 " + base64.StdEncoding.EncodeToString(HMAC)}
+		w := httptest.NewRecorder()
+		handler := WithAdminAuthz(&backend, forwardBody)
+
+		handler(w, req, ps)
+
+		resp := w.Result()
+
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Errorf("Invalid HTTP response status code: %v", resp.StatusCode)
+		}
+	})
+	t.Run("DELETE", func(t *testing.T) {
+		msg := []byte("hello")
+
+		HMAC := ComputeHMAC([]byte("/api/v1/repos/test1.repo.org"), backend.GetKey("admin0").Secret)
+		req := httptest.NewRequest("DELETE", "/api/v1/repos/test1.repo.org", bytes.NewReader(msg))
+		ps := httprouter.Params{}
+
+		req.Header["Authorization"] = []string{"admin0 " + base64.StdEncoding.EncodeToString(HMAC)}
+		w := httptest.NewRecorder()
+		handler := WithAdminAuthz(&backend, forwardBody)
+
+		handler(w, req, ps)
+
+		resp := w.Result()
+
+		if resp.StatusCode != 200 {
+			t.Errorf("Invalid HTTP response status code: %v", resp.StatusCode)
+		}
+
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("Could not read response body")
+		}
+		if !bytes.Equal(msg, respBody) {
+			t.Errorf("Invalid response body: %v", string(respBody))
+		}
+	})
+	t.Run("POST", func(t *testing.T) {
+		msg := []byte("hello")
+
+		HMAC := ComputeHMAC(msg, backend.GetKey("admin0").Secret)
+		req := httptest.NewRequest("POST", "/api/v1/repos/test1.repo.org", bytes.NewReader(msg))
+		ps := httprouter.Params{}
+
+		req.Header["Authorization"] = []string{"admin0 " + base64.StdEncoding.EncodeToString(HMAC)}
+		w := httptest.NewRecorder()
+		handler := WithAdminAuthz(&backend, forwardBody)
+
+		handler(w, req, ps)
+
+		resp := w.Result()
+
+		if resp.StatusCode != 200 {
+			t.Errorf("Invalid HTTP response status code: %v", resp.StatusCode)
+		}
+
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("Could not read response body")
+		}
+		if !bytes.Equal(msg, respBody) {
+			t.Errorf("Invalid response body: %v", string(respBody))
+		}
+	})
 }

--- a/internal/gateway/frontend/authz_test.go
+++ b/internal/gateway/frontend/authz_test.go
@@ -16,7 +16,7 @@ func TestAuthorizationMiddlewareNewLease(t *testing.T) {
 	backend := mockBackend{}
 	t.Run("POST /leases (new lease OK)", func(t *testing.T) {
 		reqBody := []byte("hello")
-		HMAC := ComputeHMAC(reqBody, backend.GetSecret("keyid2"))
+		HMAC := ComputeHMAC(reqBody, backend.GetKey("keyid2").Secret)
 		req := httptest.NewRequest("POST", "/api/v1/leases", bytes.NewReader(reqBody))
 		req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 		w := httptest.NewRecorder()
@@ -67,7 +67,7 @@ func TestAuthorizationMiddlewareNewLease(t *testing.T) {
 	})
 	t.Run("POST /leases (new lease invalid HMAC)", func(t *testing.T) {
 		reqBody := []byte("hello")
-		HMAC := ComputeHMAC([]byte("other HMAC input"), backend.GetSecret("keyid2"))
+		HMAC := ComputeHMAC([]byte("other HMAC input"), backend.GetKey("keyid2").Secret)
 		req := httptest.NewRequest("POST", "/api/v1/leases", bytes.NewReader(reqBody))
 		w := httptest.NewRecorder()
 		req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
@@ -89,7 +89,7 @@ func TestAuthorizationMiddlewareCommitLease(t *testing.T) {
 	backend := mockBackend{}
 	token := "lease_token"
 	t.Run("POST /leases/$token (commit lease OK)", func(t *testing.T) {
-		HMAC := ComputeHMAC([]byte(token), backend.GetSecret("keyid2"))
+		HMAC := ComputeHMAC([]byte(token), backend.GetKey("keyid2").Secret)
 		req := httptest.NewRequest("POST", "/api/v1/leases/"+token, nil)
 		req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 		w := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestAuthorizationMiddlewareCommitLease(t *testing.T) {
 	})
 	t.Run("POST /leases (commit lease invalid HMAC)", func(t *testing.T) {
 		reqBody := []byte("hello")
-		HMAC := ComputeHMAC([]byte("other HMAC input"), backend.GetSecret("keyid2"))
+		HMAC := ComputeHMAC([]byte("other HMAC input"), backend.GetKey("keyid2").Secret)
 		req := httptest.NewRequest("POST", "/api/v1/leases/"+token, bytes.NewReader(reqBody))
 		w := httptest.NewRecorder()
 		req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
@@ -135,7 +135,7 @@ func TestAuthorizationMiddlewareSubmitPayloadLegacy(t *testing.T) {
 		"api_version":    "2",
 	})
 
-	HMAC := ComputeHMAC(msg, backend.GetSecret("keyid2"))
+	HMAC := ComputeHMAC(msg, backend.GetKey("keyid2").Secret)
 	req := httptest.NewRequest("POST", "/api/v1/payloads", bytes.NewReader(msg))
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 	req.Header["Message-Size"] = []string{strconv.Itoa(len(msg))}
@@ -167,7 +167,7 @@ func TestAuthorizationMiddlewareSubmitPayloadNew(t *testing.T) {
 		"api_version":    "3",
 	})
 
-	HMAC := ComputeHMAC([]byte(token), backend.GetSecret("keyid2"))
+	HMAC := ComputeHMAC([]byte(token), backend.GetKey("keyid2").Secret)
 	req := httptest.NewRequest("POST", "/api/v1/payloads/"+token, bytes.NewReader(msg))
 
 	ps := httprouter.Params{httprouter.Param{Key: "token", Value: token}}

--- a/internal/gateway/frontend/frontend.go
+++ b/internal/gateway/frontend/frontend.go
@@ -54,6 +54,7 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 	// Admin routes
 	router.POST(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))
 	router.DELETE(APIRoot+"/leases-by-path/*path", amw(MakeAdminLeasesHandler(services)))
+	router.POST(APIRoot+"/gc", amw(MakeGCHandler(services)))
 
 	// Configure and start the HTTP server
 	srv := &http.Server{

--- a/internal/gateway/frontend/frontend.go
+++ b/internal/gateway/frontend/frontend.go
@@ -53,8 +53,7 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 
 	// Admin routes
 	router.POST(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))
-
-	router.DELETE(APIRoot+"/leases/by-path/:path", amw(MakeAdminLeasesHandler(services)))
+	router.DELETE(APIRoot+"/leases-by-path/*path", amw(MakeAdminLeasesHandler(services)))
 
 	// Configure and start the HTTP server
 	srv := &http.Server{

--- a/internal/gateway/frontend/frontend.go
+++ b/internal/gateway/frontend/frontend.go
@@ -54,6 +54,8 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 	// Admin routes
 	router.POST(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))
 
+	router.DELETE(APIRoot+"/leases/by-path/:path", amw(MakeAdminLeasesHandler(services)))
+
 	// Configure and start the HTTP server
 	srv := &http.Server{
 		Handler:      router,

--- a/internal/gateway/frontend/frontend.go
+++ b/internal/gateway/frontend/frontend.go
@@ -25,7 +25,12 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 		return WithTag(WithAuthz(services, h))
 	}
 
-	// Register the different routes
+	// middleware with tagging and admin authorization
+	amw := func(h httprouter.Handle) httprouter.Handle {
+		return WithTag(WithAdminAuthz(services, h))
+	}
+
+	// Regular routes
 
 	// Root handler
 	router.GET(APIRoot, tag(NewRootHandler()))
@@ -45,6 +50,9 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 	router.POST(APIRoot+"/payloads", mw(MakePayloadsHandler(services)))
 	// Payloads (new and improved)
 	router.POST(APIRoot+"/payloads/:token", mw(MakePayloadsHandler(services)))
+
+	// Admin routes
+	router.DELETE(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))
 
 	// Configure and start the HTTP server
 	srv := &http.Server{

--- a/internal/gateway/frontend/frontend.go
+++ b/internal/gateway/frontend/frontend.go
@@ -52,7 +52,7 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 	router.POST(APIRoot+"/payloads/:token", mw(MakePayloadsHandler(services)))
 
 	// Admin routes
-	router.DELETE(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))
+	router.POST(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))
 
 	// Configure and start the HTTP server
 	srv := &http.Server{

--- a/internal/gateway/frontend/gc.go
+++ b/internal/gateway/frontend/gc.go
@@ -1,0 +1,28 @@
+package frontend
+
+import (
+	"encoding/json"
+	"net/http"
+
+	be "github.com/cvmfs/gateway/internal/gateway/backend"
+	"github.com/julienschmidt/httprouter"
+)
+
+// MakeGCHandler creates an HTTP handler for the "/gc" endpoint
+func MakeGCHandler(services be.ActionController) httprouter.Handle {
+	return func(w http.ResponseWriter, h *http.Request, ps httprouter.Params) {
+		ctx := h.Context()
+
+		var options be.GCOptions
+		if err := json.NewDecoder(h.Body).Decode(&options); err != nil {
+			httpWrapError(ctx, err, "invalid request body", w, http.StatusBadRequest)
+			return
+		}
+
+		msg := map[string]interface{}{"status": "ok"}
+		if err := services.RunGC(ctx, options); err != nil {
+			msg["status"] = "error"
+			msg["reason"] = err.Error()
+		}
+	}
+}

--- a/internal/gateway/frontend/gc.go
+++ b/internal/gateway/frontend/gc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	gw "github.com/cvmfs/gateway/internal/gateway"
 	be "github.com/cvmfs/gateway/internal/gateway/backend"
 	"github.com/julienschmidt/httprouter"
 )
@@ -20,9 +21,15 @@ func MakeGCHandler(services be.ActionController) httprouter.Handle {
 		}
 
 		msg := map[string]interface{}{"status": "ok"}
-		if err := services.RunGC(ctx, options); err != nil {
+		if output, err := services.RunGC(ctx, options); err != nil {
 			msg["status"] = "error"
 			msg["reason"] = err.Error()
+		} else {
+			msg["output"] = output
 		}
+
+		gw.LogC(ctx, "http", gw.LogInfo).Msg("request processed")
+
+		replyJSON(ctx, w, msg)
 	}
 }

--- a/internal/gateway/frontend/leases_test.go
+++ b/internal/gateway/frontend/leases_test.go
@@ -19,7 +19,7 @@ func TestLeaseHandlerNewLease(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/api/v1/leases", bytes.NewReader(msg))
-	HMAC := ComputeHMAC(msg, backend.GetSecret("keyid2"))
+	HMAC := ComputeHMAC(msg, backend.GetKey("keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 
 	w := httptest.NewRecorder()
@@ -50,7 +50,7 @@ func TestLeaseHandlerCancelLease(t *testing.T) {
 	backend := mockBackend{}
 	token := "lease_token"
 	req := httptest.NewRequest("DELETE", "/api/v1/leases/"+token, nil)
-	HMAC := ComputeHMAC([]byte(token), backend.GetSecret("keyid2"))
+	HMAC := ComputeHMAC([]byte(token), backend.GetKey("keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 
 	w := httptest.NewRecorder()
@@ -88,7 +88,7 @@ func TestLeaseHandlerCommitLease(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/api/v1/leases/"+token, bytes.NewReader(msg))
-	HMAC := ComputeHMAC([]byte(token), backend.GetSecret("keyid2"))
+	HMAC := ComputeHMAC([]byte(token), backend.GetKey("keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 
 	w := httptest.NewRecorder()

--- a/internal/gateway/frontend/leases_test.go
+++ b/internal/gateway/frontend/leases_test.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
@@ -19,7 +20,7 @@ func TestLeaseHandlerNewLease(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/api/v1/leases", bytes.NewReader(msg))
-	HMAC := ComputeHMAC(msg, backend.GetKey("keyid2").Secret)
+	HMAC := ComputeHMAC(msg, backend.GetKey(context.TODO(), "keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 
 	w := httptest.NewRecorder()
@@ -50,7 +51,7 @@ func TestLeaseHandlerCancelLease(t *testing.T) {
 	backend := mockBackend{}
 	token := "lease_token"
 	req := httptest.NewRequest("DELETE", "/api/v1/leases/"+token, nil)
-	HMAC := ComputeHMAC([]byte(token), backend.GetKey("keyid2").Secret)
+	HMAC := ComputeHMAC([]byte(token), backend.GetKey(context.TODO(), "keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 
 	w := httptest.NewRecorder()
@@ -88,7 +89,7 @@ func TestLeaseHandlerCommitLease(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/api/v1/leases/"+token, bytes.NewReader(msg))
-	HMAC := ComputeHMAC([]byte(token), backend.GetKey("keyid2").Secret)
+	HMAC := ComputeHMAC([]byte(token), backend.GetKey(context.TODO(), "keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 
 	w := httptest.NewRecorder()

--- a/internal/gateway/frontend/payloads_test.go
+++ b/internal/gateway/frontend/payloads_test.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -25,7 +26,7 @@ func TestPayloadHandlerLegacy(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/api/v1/payloads", bytes.NewReader(msg))
-	HMAC := ComputeHMAC(msg, backend.GetKey("keyid2").Secret)
+	HMAC := ComputeHMAC(msg, backend.GetKey(context.TODO(), "keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 	req.Header["Message-Size"] = []string{strconv.Itoa(len(msg))}
 
@@ -63,7 +64,7 @@ func TestPayloadHandlerNew(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/api/v1/payloads", bytes.NewReader(msg))
-	HMAC := ComputeHMAC([]byte(token), backend.GetKey("keyid2").Secret)
+	HMAC := ComputeHMAC([]byte(token), backend.GetKey(context.TODO(), "keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 	req.Header["Message-Size"] = []string{fmt.Sprintf("%v", len(msg))}
 

--- a/internal/gateway/frontend/payloads_test.go
+++ b/internal/gateway/frontend/payloads_test.go
@@ -25,7 +25,7 @@ func TestPayloadHandlerLegacy(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/api/v1/payloads", bytes.NewReader(msg))
-	HMAC := ComputeHMAC(msg, backend.GetSecret("keyid2"))
+	HMAC := ComputeHMAC(msg, backend.GetKey("keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 	req.Header["Message-Size"] = []string{strconv.Itoa(len(msg))}
 
@@ -63,7 +63,7 @@ func TestPayloadHandlerNew(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("POST", "/api/v1/payloads", bytes.NewReader(msg))
-	HMAC := ComputeHMAC([]byte(token), backend.GetSecret("keyid2"))
+	HMAC := ComputeHMAC([]byte(token), backend.GetKey("keyid2").Secret)
 	req.Header["Authorization"] = []string{"keyid2 " + base64.StdEncoding.EncodeToString(HMAC)}
 	req.Header["Message-Size"] = []string{fmt.Sprintf("%v", len(msg))}
 

--- a/internal/gateway/frontend/repos.go
+++ b/internal/gateway/frontend/repos.go
@@ -16,7 +16,7 @@ func MakeReposHandler(services be.ActionController) httprouter.Handle {
 		msg := make(map[string]interface{})
 
 		if repoName := ps.ByName("name"); repoName != "" {
-			rc := services.GetRepo(repoName)
+			rc := services.GetRepo(ctx, repoName)
 			if rc == nil {
 				msg["status"] = "error"
 				msg["reason"] = "invalid_repo"
@@ -26,7 +26,7 @@ func MakeReposHandler(services be.ActionController) httprouter.Handle {
 			}
 		} else {
 			msg["status"] = "ok"
-			msg["data"] = services.GetRepos()
+			msg["data"] = services.GetRepos(ctx)
 		}
 
 		gw.LogC(ctx, "http", gw.LogInfo).Msg("request processed")

--- a/internal/gateway/frontend/repos.go
+++ b/internal/gateway/frontend/repos.go
@@ -15,13 +15,13 @@ func MakeReposHandler(services be.ActionController) httprouter.Handle {
 		msg := make(map[string]interface{})
 
 		if repoName := ps.ByName("name"); repoName != "" {
-			r := services.GetRepo(repoName)
-			if len(r) == 0 {
+			rc := services.GetRepo(repoName)
+			if len(rc.Keys) == 0 {
 				msg["status"] = "error"
 				msg["reason"] = "invalid_repo"
 			} else {
 				msg["status"] = "ok"
-				msg["data"] = r
+				msg["data"] = rc
 			}
 		} else {
 			msg["status"] = "ok"

--- a/internal/gateway/frontend/repos.go
+++ b/internal/gateway/frontend/repos.go
@@ -16,7 +16,7 @@ func MakeReposHandler(services be.ActionController) httprouter.Handle {
 
 		if repoName := ps.ByName("name"); repoName != "" {
 			rc := services.GetRepo(repoName)
-			if len(rc.Keys) == 0 {
+			if rc == nil {
 				msg["status"] = "error"
 				msg["reason"] = "invalid_repo"
 			} else {

--- a/internal/gateway/frontend/repos.go
+++ b/internal/gateway/frontend/repos.go
@@ -33,3 +33,29 @@ func MakeReposHandler(services be.ActionController) httprouter.Handle {
 		replyJSON(ctx, w, msg)
 	}
 }
+
+// MakeAdminReposHandler creates an HTTP handler for the API root
+func MakeAdminReposHandler(services be.ActionController) httprouter.Handle {
+	return func(w http.ResponseWriter, h *http.Request, ps httprouter.Params) {
+		ctx := h.Context()
+		msg := make(map[string]interface{})
+
+		if repoName := ps.ByName("name"); repoName != "" {
+			rc := services.GetRepo(repoName)
+			if rc == nil {
+				msg["status"] = "error"
+				msg["reason"] = "invalid_repo"
+			} else {
+				msg["status"] = "ok"
+				msg["data"] = rc
+			}
+		} else {
+			msg["status"] = "ok"
+			msg["data"] = services.GetRepos()
+		}
+
+		gw.LogC(ctx, "http", gw.LogInfo).Msg("request processed")
+
+		replyJSON(ctx, w, msg)
+	}
+}

--- a/internal/gateway/frontend/repos.go
+++ b/internal/gateway/frontend/repos.go
@@ -53,7 +53,7 @@ func MakeAdminReposHandler(services be.ActionController) httprouter.Handle {
 		repoName := ps.ByName("name")
 
 		msg := make(map[string]interface{})
-		if err := services.SetRepoEnabled(ctx, repoName, reqMsg.Enable, reqMsg.Wait); err != nil {
+		if err := services.SetRepoEnabled(ctx, repoName, reqMsg.Enable); err != nil {
 			if _, ok := err.(be.RepoBusyError); ok {
 				msg["status"] = "repo_busy"
 			} else {

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -49,6 +49,10 @@ func (b *mockBackend) GetRepos() map[string]be.RepositoryConfig {
 	}
 }
 
+func (b *mockBackend) SetRepoEnabled(ctx context.Context, name string, enabled bool, wait bool) error {
+	return nil
+}
+
 func (b *mockBackend) NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error) {
 	return "lease_token_string", nil
 }

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -31,20 +31,17 @@ func (b *mockBackend) GetKey(keyID string) *be.KeyConfig {
 
 func (b *mockBackend) GetRepo(repoName string) *be.RepositoryConfig {
 	return &be.RepositoryConfig{
-		Keys:    be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"},
-		Enabled: true,
+		Keys: be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"},
 	}
 }
 
 func (b *mockBackend) GetRepos() map[string]be.RepositoryConfig {
 	return map[string]be.RepositoryConfig{
 		"test1.repo.org": be.RepositoryConfig{
-			Keys:    be.KeyPaths{"keyid123": "/"},
-			Enabled: true,
+			Keys: be.KeyPaths{"keyid123": "/"},
 		},
 		"test2.repo.org": be.RepositoryConfig{
-			Keys:    be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"},
-			Enabled: true,
+			Keys: be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"},
 		},
 	}
 }

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -49,7 +49,7 @@ func (b *mockBackend) GetRepos() map[string]be.RepositoryConfig {
 	}
 }
 
-func (b *mockBackend) SetRepoEnabled(ctx context.Context, name string, enabled bool, wait bool) error {
+func (b *mockBackend) SetRepoEnabled(ctx context.Context, repository string, enabled bool, wait bool) error {
 	return nil
 }
 
@@ -76,6 +76,10 @@ func (b *mockBackend) GetLease(ctx context.Context, tokenStr string) (*be.LeaseR
 		LeasePath: "test2.repo.org/some/path/one",
 		Expires:   time.Now().Add(60 * time.Second).String(),
 	}, nil
+}
+
+func (b *mockBackend) CancelLeases(ctx context.Context, repoPath string) error {
+	return nil
 }
 
 func (b *mockBackend) CancelLease(ctx context.Context, tokenStr string) error {

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -26,7 +26,7 @@ func (b *mockBackend) GetKey(keyID string) *be.KeyConfig {
 	if strings.HasPrefix(keyID, "admin") {
 		admin = true
 	}
-	return &be.KeyConfig{Secret: "big_secret", Admin: admin, Enabled: true}
+	return &be.KeyConfig{Secret: "big_secret", Admin: admin}
 }
 
 func (b *mockBackend) GetRepo(repoName string) *be.RepositoryConfig {

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -46,7 +46,7 @@ func (b *mockBackend) GetRepos(ctx context.Context) map[string]be.RepositoryConf
 	}
 }
 
-func (b *mockBackend) SetRepoEnabled(ctx context.Context, repository string, enabled bool, wait bool) error {
+func (b *mockBackend) SetRepoEnabled(ctx context.Context, repository string, enabled bool) error {
 	return nil
 }
 

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -93,3 +93,7 @@ func (b *mockBackend) CommitLease(ctx context.Context, tokenStr, oldRootHash, ne
 func (b *mockBackend) SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error {
 	return nil
 }
+
+func (b *mockBackend) RunGC(ctx context.Context, options be.GCOptions) error {
+	return nil
+}

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -24,20 +24,30 @@ func (b *mockBackend) GetSecret(keyID string) string {
 	return "big_secret"
 }
 
-func (b *mockBackend) GetRepo(repoName string) be.KeyPaths {
-	return be.KeyPaths{
-		"keyid1": be.KeySettings{Path: "/", Admin: true},
-		"keyid2": be.KeySettings{Path: "/restricted/to/subdir", Admin: false}}
-}
-
-func (b *mockBackend) GetRepos() map[string]be.KeyPaths {
-	return map[string]be.KeyPaths{
-		"test1.repo.org": be.KeyPaths{
-			"keyid123": be.KeySettings{Path: "/", Admin: true},
-		},
-		"test2.repo.org": be.KeyPaths{
+func (b *mockBackend) GetRepo(repoName string) be.RepositoryConfig {
+	return be.RepositoryConfig{
+		Keys: map[string]be.KeySettings{
 			"keyid1": be.KeySettings{Path: "/", Admin: true},
 			"keyid2": be.KeySettings{Path: "/restricted/to/subdir", Admin: false},
+		},
+		Enabled: true,
+	}
+}
+
+func (b *mockBackend) GetRepos() map[string]be.RepositoryConfig {
+	return map[string]be.RepositoryConfig{
+		"test1.repo.org": be.RepositoryConfig{
+			Keys: map[string]be.KeySettings{
+				"keyid123": be.KeySettings{Path: "/", Admin: true},
+			},
+			Enabled: true,
+		},
+		"test2.repo.org": be.RepositoryConfig{
+			Keys: map[string]be.KeySettings{
+				"keyid1": be.KeySettings{Path: "/", Admin: true},
+				"keyid2": be.KeySettings{Path: "/restricted/to/subdir", Admin: false},
+			},
+			Enabled: true,
 		},
 	}
 }

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -20,16 +20,13 @@ func forwardBody(w http.ResponseWriter, req *http.Request, _ httprouter.Params) 
 type mockBackend struct {
 }
 
-func (b *mockBackend) GetSecret(keyID string) string {
-	return "big_secret"
+func (b *mockBackend) GetKey(keyID string) *be.KeyConfig {
+	return &be.KeyConfig{Secret: "big_secret", Admin: false, Enabled: true}
 }
 
-func (b *mockBackend) GetRepo(repoName string) be.RepositoryConfig {
-	return be.RepositoryConfig{
-		Keys: map[string]be.KeySettings{
-			"keyid1": be.KeySettings{Path: "/", Admin: true},
-			"keyid2": be.KeySettings{Path: "/restricted/to/subdir", Admin: false},
-		},
+func (b *mockBackend) GetRepo(repoName string) *be.RepositoryConfig {
+	return &be.RepositoryConfig{
+		Keys:    be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"},
 		Enabled: true,
 	}
 }
@@ -37,16 +34,11 @@ func (b *mockBackend) GetRepo(repoName string) be.RepositoryConfig {
 func (b *mockBackend) GetRepos() map[string]be.RepositoryConfig {
 	return map[string]be.RepositoryConfig{
 		"test1.repo.org": be.RepositoryConfig{
-			Keys: map[string]be.KeySettings{
-				"keyid123": be.KeySettings{Path: "/", Admin: true},
-			},
+			Keys:    be.KeyPaths{"keyid123": "/"},
 			Enabled: true,
 		},
 		"test2.repo.org": be.RepositoryConfig{
-			Keys: map[string]be.KeySettings{
-				"keyid1": be.KeySettings{Path: "/", Admin: true},
-				"keyid2": be.KeySettings{Path: "/restricted/to/subdir", Admin: false},
-			},
+			Keys:    be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"},
 			Enabled: true,
 		},
 	}

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -21,7 +21,7 @@ func forwardBody(w http.ResponseWriter, req *http.Request, _ httprouter.Params) 
 type mockBackend struct {
 }
 
-func (b *mockBackend) GetKey(keyID string) *be.KeyConfig {
+func (b *mockBackend) GetKey(ctx context.Context, keyID string) *be.KeyConfig {
 	admin := false
 	if strings.HasPrefix(keyID, "admin") {
 		admin = true
@@ -29,13 +29,13 @@ func (b *mockBackend) GetKey(keyID string) *be.KeyConfig {
 	return &be.KeyConfig{Secret: "big_secret", Admin: admin}
 }
 
-func (b *mockBackend) GetRepo(repoName string) *be.RepositoryConfig {
+func (b *mockBackend) GetRepo(ctx context.Context, repoName string) *be.RepositoryConfig {
 	return &be.RepositoryConfig{
 		Keys: be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"},
 	}
 }
 
-func (b *mockBackend) GetRepos() map[string]be.RepositoryConfig {
+func (b *mockBackend) GetRepos(ctx context.Context) map[string]be.RepositoryConfig {
 	return map[string]be.RepositoryConfig{
 		"test1.repo.org": be.RepositoryConfig{
 			Keys: be.KeyPaths{"keyid123": "/"},

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	gw "github.com/cvmfs/gateway/internal/gateway"
@@ -21,7 +22,11 @@ type mockBackend struct {
 }
 
 func (b *mockBackend) GetKey(keyID string) *be.KeyConfig {
-	return &be.KeyConfig{Secret: "big_secret", Admin: false, Enabled: true}
+	admin := false
+	if strings.HasPrefix(keyID, "admin") {
+		admin = true
+	}
+	return &be.KeyConfig{Secret: "big_secret", Admin: admin, Enabled: true}
 }
 
 func (b *mockBackend) GetRepo(repoName string) *be.RepositoryConfig {

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -25,13 +25,20 @@ func (b *mockBackend) GetSecret(keyID string) string {
 }
 
 func (b *mockBackend) GetRepo(repoName string) be.KeyPaths {
-	return be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"}
+	return be.KeyPaths{
+		"keyid1": be.KeySettings{Path: "/", Admin: true},
+		"keyid2": be.KeySettings{Path: "/restricted/to/subdir", Admin: false}}
 }
 
 func (b *mockBackend) GetRepos() map[string]be.KeyPaths {
 	return map[string]be.KeyPaths{
-		"test1.repo.org": be.KeyPaths{"keyid123": "/"},
-		"test2.repo.org": be.KeyPaths{"keyid1": "/", "keyid2": "/restricted/to/subdir"},
+		"test1.repo.org": be.KeyPaths{
+			"keyid123": be.KeySettings{Path: "/", Admin: true},
+		},
+		"test2.repo.org": be.KeyPaths{
+			"keyid1": be.KeySettings{Path: "/", Admin: true},
+			"keyid2": be.KeySettings{Path: "/restricted/to/subdir", Admin: false},
+		},
 	}
 }
 

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -91,6 +91,6 @@ func (b *mockBackend) SubmitPayload(ctx context.Context, token string, payload i
 	return nil
 }
 
-func (b *mockBackend) RunGC(ctx context.Context, options be.GCOptions) error {
-	return nil
+func (b *mockBackend) RunGC(ctx context.Context, options be.GCOptions) (string, error) {
+	return "", nil
 }

--- a/pkg/cvmfs-gateway@.service
+++ b/pkg/cvmfs-gateway@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=CernVM-FS Repository Gateway
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/cvmfs_gateway
+StandardOutput=journal
+Restart=always
+RestartSec=5
+User=%I
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/run_cvmfs_gateway.sh
+++ b/pkg/run_cvmfs_gateway.sh
@@ -11,16 +11,21 @@ fi
 
 action=$1
 
+user=$2
+if [ "x$user" = "x" ]; then
+    user=root
+fi
+
 if [ x"$action" = xstart ]; then
     if $has_systemd; then
-        systemctl start cvmfs-gateway
+        systemctl start cvmfs-gateway@$user
     else
         service cvmfs-gateway start
     fi
     echo "CVMFS repository gateway started."
 elif [ x"$action" = xstop ]; then
     if $has_systemd; then
-        systemctl stop cvmfs-gateway
+        systemctl stop cvmfs-gateway@$user
     else
         service cvmfs-gateway stop
     fi
@@ -29,16 +34,16 @@ elif [ x"$action" = xreload ]; then
     echo "Reloading the CVMFS repository gateway is not implemented. Please use restart."
 elif [ x"$action" = xrestart ]; then
     if $has_systemd; then
-        systemctl restart cvmfs-gateway
+        systemctl restart cvmfs-gateway@$user
     else
         service cvmfs-gateway restart
     fi
     echo "CVMFS repository gateway restarted."
 elif [ x"$action" = xstatus ]; then
     if $has_systemd; then
-        systemctl restart cvmfs-gateway > /dev/null 2>&1
+        systemctl status cvmfs-gateway@$user > /dev/null 2>&1
     else
-        service cvmfs-gateway restart > /dev/null 2>&1
+        service cvmfs-gateway status > /dev/null 2>&1
     fi
     retval=$?
     if [ "x$retval" = "x0" ]; then
@@ -48,6 +53,6 @@ elif [ x"$action" = xstatus ]; then
     fi
 else
     echo "Unknown action: $action"
-    echo "Usage: run_cvmfs_gateway.sh <start|stop|reload|restart|status>"
+    echo "Usage: run_cvmfs_gateway.sh <start|stop|reload|restart|status> [USER]"
     exit 1
 fi

--- a/pkg/spec/pre
+++ b/pkg/spec/pre
@@ -2,7 +2,12 @@
 
 if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     if [ "x$(systemctl list-unit-files | grep cvmfs-gateway)" != "x" ]; then
-        systemctl stop cvmfs-gateway
+        if $(systemctl is-active --quiet cvmfs-gateway); then
+            systemctl stop cvmfs-gateway
+        fi
+        if $(systemctl is-active --quiet cvmfs-gateway@*); then
+            systemctl stop cvmfs-gateway@*
+        fi
     fi
 else
     if [ -x /usr/libexec/cvmfs-gateway/run_cvmfs_gateway.sh ]; then

--- a/pkg/spec/preun
+++ b/pkg/spec/preun
@@ -2,7 +2,12 @@
 
 if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
     if [ "x$(systemctl list-unit-files | grep cvmfs-gateway)" != "x" ]; then
-        systemctl stop cvmfs-gateway
+        if $(systemctl is-active --quiet cvmfs-gateway); then
+            systemctl stop cvmfs-gateway
+        fi
+        if $(systemctl is-active --quiet cvmfs-gateway@*); then
+            systemctl stop cvmfs-gateway@*
+        fi
     fi
 else
     if [ -x /usr/libexec/cvmfs-gateway/run_cvmfs_gateway.sh ]; then

--- a/tools/test_requests.py
+++ b/tools/test_requests.py
@@ -25,7 +25,7 @@ def toggle_repo(args):
     req = {'enable': bool(args.enable)}
     headers = make_headers(args.key_id, args.secret, json.dumps(req))
     rep = requests.post(args.gw_url + '/repos/' +
-                        args.repo_name, json=req, headers=headers)
+                        args.repo, json=req, headers=headers)
     print(json.dumps(rep.json()))
 
 def get_leases(args):
@@ -87,6 +87,18 @@ def submit_payload(args):
     rep = requests.post(req_url, json=req, headers=headers)
     print(json.dumps(rep.json()))
 
+def gc(args):
+    req = {
+        'repo': args.repo,
+        'num_revisions': args.num_revisions,
+        'timestamp': args.timestamp,
+        'dry_run': args.dry_run,
+        'verbose': args.verbose
+    }
+    headers = make_headers(args.key_id, args.secret, json.dumps(req))
+    rep = requests.post(args.gw_url + '/gc', json=req, headers=headers)
+    print(json.dumps(rep.json()))
+
 def main():
     parser = argparse.ArgumentParser(description='Test gateway API requests')
     parser.add_argument('--gw_url', required=True,
@@ -110,7 +122,7 @@ def main():
     parser_toggle_repo.add_argument(
         '--wait', required=False, action='store_true', default=False, help='wait until the repository can be disabled')
     parser_toggle_repo.add_argument(
-        '--repo_name', required=True, help='name of the concerned repository')
+        '--repo', required=True, help='name of the concerned repository')
 
     subparsers.add_parser(
         'get_leases', help='get active leases'
@@ -152,6 +164,15 @@ def main():
     parser_submit_payload.add_argument(
         '--legacy', required=False, default=False, action='store_true', help='use legacy request format')
 
+    parser_gc = subparsers.add_parser(
+        'gc', help='trigger garbage collection for a repository'
+    )
+    parser_gc.add_argument('--repo', required=True, help='name of the repository')
+    parser_gc.add_argument('--num_revisions', required=False, help='number of revisions to keep')
+    parser_gc.add_argument('--timestamp', required=False, help='threshold timestamp for garbage collection')
+    parser_gc.add_argument('--dry_run', required=False, default=False, action='store_true', help='dry run')
+    parser_gc.add_argument('--verbose', required=False, default=False, action='store_true', help='verbose output')
+
     args = parser.parse_args()
 
     {
@@ -164,6 +185,7 @@ def main():
         'cancel_leases': cancel_leases,
         'commit_lease': commit_lease,
         'submit_payload': submit_payload,
+        'gc': gc,
     }[args.command](args)
 
 

--- a/tools/test_requests.py
+++ b/tools/test_requests.py
@@ -53,6 +53,14 @@ def cancel_lease(args):
     rep = requests.delete(args.gw_url + '/leases/' + token, headers=headers)
     print(json.dumps(rep.json()))
 
+def cancel_leases(args):
+    prefix = args.prefix
+    hmac_msg = ('/api/v1/leases-by-path/' + prefix).encode()
+    headers = {'authorization': args.key_id +
+                ' ' + computeHMAC(hmac_msg, args.secret.encode())}
+    rep = requests.delete(args.gw_url + '/leases-by-path/' + prefix, headers=headers)
+    print(json.dumps(rep.json()))
+
 def commit_lease(args):
     token = args.token
     hmac_msg = token.encode()
@@ -129,19 +137,24 @@ def main():
     parser_new_lease.add_argument('--path', required=True, help="lease path")
 
     parser_cancel_lease = subparsers.add_parser(
-        'cancel_lease', help='request a new active lease'
+        'cancel_lease', help='cancel a lease using a token'
     )
     parser_cancel_lease.add_argument('--token', required=True, help='lease token string')
 
+    parser_cancel_leases = subparsers.add_parser(
+        'cancel_leases', help='cancel all leases under a prefix'
+    )
+    parser_cancel_leases.add_argument('--prefix', required=True, help='repository+path prefix')
+
     parser_commit_lease = subparsers.add_parser(
-        'commit_lease', help='request a new active lease'
+        'commit_lease', help='commit a lease'
     )
     parser_commit_lease.add_argument('--token', required=True, help='lease token string')
     parser_commit_lease.add_argument('--old_hash', required=True, help='old root hash')
     parser_commit_lease.add_argument('--new_hash', required=True, help='new root hash')
 
     parser_submit_payload = subparsers.add_parser(
-        'submit_payload', help='request a new active lease'
+        'submit_payload', help='submit a payload'
     )
     parser_submit_payload.add_argument('--token', required=True, help='lease token string')
     parser_submit_payload.add_argument('--digest', required=True, help='payload digest')
@@ -158,6 +171,7 @@ def main():
         'get_lease': get_lease,
         'new_lease': new_lease,
         'cancel_lease': cancel_lease,
+        'cancel_leases': cancel_leases,
         'commit_lease': commit_lease,
         'submit_payload': submit_payload,
     }[args.command](args)

--- a/tools/test_requests.py
+++ b/tools/test_requests.py
@@ -20,50 +20,44 @@ def get_repos(args):
     rep = requests.get(args.gw_url + '/repos')
     print(json.dumps(rep.json()))
 
-
-def toggle_repos(args):
+def toggle_repo(args):
     req = {'enable': bool(args.enable)}
     hmac_msg = json.dumps(req).encode()
     headers = {'authorization': args.key_id +
-                ' ' + computeHMAC(hmac_msg, args.secret)}
+                ' ' + computeHMAC(hmac_msg, args.secret.encode())}
     rep = requests.post(args.gw_url + '/repos/' +
                         args.repo_name, json=req, headers=headers)
     print(json.dumps(rep.json()))
-
 
 def get_leases(args):
     rep = requests.get(args.gw_url + '/leases')
     print(json.dumps(rep.json()))
 
-
 def get_lease(args):
     rep = requests.get(args.gw_url + '/leases/' + args.token)
     print(json.dumps(rep.json()))
-
 
 def new_lease(args):
     req = {'path': args.path, 'api_version': '2'}
     hmac_msg = json.dumps(req).encode()
     headers = {'authorization': args.key_id +
-                ' ' + computeHMAC(hmac_msg, args.secret)}
+                ' ' + computeHMAC(hmac_msg, args.secret.encode())}
     rep = requests.post(args.gw_url + '/leases', json=req, headers=headers)
     print(json.dumps(rep.json()))
-
 
 def cancel_lease(args):
     token = args.token
     hmac_msg = token.encode()
     headers = {'authorization': args.key_id +
-                ' ' + computeHMAC(hmac_msg, args.secret)}
+                ' ' + computeHMAC(hmac_msg, args.secret.encode())}
     rep = requests.delete(args.gw_url + '/leases/' + token, headers=headers)
     print(json.dumps(rep.json()))
-
 
 def commit_lease(args):
     token = args.token
     hmac_msg = token.encode()
     headers = {'authorization': args.key_id +
-                ' ' + computeHMAC(hmac_msg, args.secret)}
+                ' ' + computeHMAC(hmac_msg, args.secret.encode())}
     req = {'old_root_hash': args.old_hash,
            'new_root_hash': args.new_hash,
            'tag_name': 'mytag',
@@ -72,7 +66,6 @@ def commit_lease(args):
     rep = requests.post(args.gw_url + '/leases/' + token,
                         json=req, headers=headers)
     print(json.dumps(rep.json()))
-
 
 def submit_payload(args):
     hmac_msg = None
@@ -91,11 +84,10 @@ def submit_payload(args):
         hmac_msg = args.token.encode()
         req_url = args.gw_url + '/payloads' + args.token
 
-    headers = {'authorization': args.key_id + ' ' + computeHMAC(hmac_msg, args.secret),
+    headers = {'authorization': args.key_id + ' ' + computeHMAC(hmac_msg, args.secret.encode()),
                'message-size': str(len(json.dumps(req)))}
     rep = requests.post(req_url, json=req, headers=headers)
     print(json.dumps(rep.json()))
-
 
 def main():
     parser = argparse.ArgumentParser(description='Test gateway API requests')
@@ -105,14 +97,13 @@ def main():
                         help='Public ID of the secret key used to sign the request')
     parser.add_argument('--secret', required=True,
                         help='Secret key to be used to sign the request')
-    subparsers = parser.add_subparsers(help='sub-command help')
+    subparsers = parser.add_subparsers(help='subcommands')
+    subparsers.required = True
+    subparsers.dest = 'command'
 
-
-    parser_get_repos = subparsers.add_parser(
+    subparsers.add_parser(
         'get_repos', help='get a list of all repositories'
     )
-    parser_get_repos.set_defaults(func=get_repos)
-
 
     parser_toggle_repo = subparsers.add_parser(
         'toggle_repo', help='enable or disable a repository')
@@ -122,35 +113,25 @@ def main():
         '--wait', required=False, action='store_true', default=False, help='wait until the repository can be disabled')
     parser_toggle_repo.add_argument(
         '--repo_name', required=True, help='name of the concerned repository')
-    parser_toggle_repo.set_defaults(func=toggle_repos)
 
-
-    parser_get_leases = subparsers.add_parser(
+    subparsers.add_parser(
         'get_leases', help='get active leases'
     )
-    parser_get_leases.set_defaults(func=get_leases)
-
 
     parser_get_lease = subparsers.add_parser(
         'get_lease', help='get an active lease'
     )
     parser_get_lease.add_argument('--token', required=True, help='lease token string')
-    parser_get_lease.set_defaults(func=get_lease)
-
 
     parser_new_lease = subparsers.add_parser(
         'new_lease', help='request a new active lease'
     )
     parser_new_lease.add_argument('--path', required=True, help="lease path")
-    parser_new_lease.set_defaults(func=new_lease)
-
 
     parser_cancel_lease = subparsers.add_parser(
         'cancel_lease', help='request a new active lease'
     )
     parser_cancel_lease.add_argument('--token', required=True, help='lease token string')
-    parser_cancel_lease.set_defaults(func=cancel_lease)
-
 
     parser_commit_lease = subparsers.add_parser(
         'commit_lease', help='request a new active lease'
@@ -158,8 +139,6 @@ def main():
     parser_commit_lease.add_argument('--token', required=True, help='lease token string')
     parser_commit_lease.add_argument('--old_hash', required=True, help='old root hash')
     parser_commit_lease.add_argument('--new_hash', required=True, help='new root hash')
-    parser_commit_lease.set_defaults(func=commit_lease)
-
 
     parser_submit_payload = subparsers.add_parser(
         'submit_payload', help='request a new active lease'
@@ -169,9 +148,19 @@ def main():
     parser_submit_payload.add_argument('--header_size', required=True, help='payload object pack header size')
     parser_submit_payload.add_argument(
         '--legacy', required=False, default=False, action='store_true', help='use legacy request format')
-    parser_submit_payload.set_defaults(func=submit_payload)
 
-    parser.parse_args()
+    args = parser.parse_args()
+
+    {
+        'get_repos': get_repos,
+        'toggle_repo': toggle_repo,
+        'get_leases': get_leases,
+        'get_lease': get_lease,
+        'new_lease': new_lease,
+        'cancel_lease': cancel_lease,
+        'commit_lease': commit_lease,
+        'submit_payload': submit_payload,
+    }[args.command](args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses [CVM-1685](https://sft.its.cern.ch/jira/browse/CVM-1685).

Adds endpoints for administration tasks:
* Cancelling leases based on path (without lease token)
* Temporarily disable repositories until subsequent restart
* Run garbage collection

All administration requests need to be signed with an administration key.