### PR TITLE
Notifications

### DIFF
--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -34,6 +34,7 @@ type ActionController interface {
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error
 	RunGC(ctx context.Context, options GCOptions) (string, error)
 	PublishManifest(ctx context.Context, repository string, message []byte) error
+	SubscribeToNotifications(ctx context.Context, repository string) <-chan NotificationMessage
 }
 
 // GetKey returns the key configuration associated with a key ID

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -32,6 +32,7 @@ type ActionController interface {
 	CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag) error
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error
 	RunGC(ctx context.Context, options GCOptions) (string, error)
+	PublishManifest(ctx context.Context, repository string, message []byte) error
 }
 
 // GetKey returns the key configuration associated with a key ID

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -34,7 +34,8 @@ type ActionController interface {
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error
 	RunGC(ctx context.Context, options GCOptions) (string, error)
 	PublishManifest(ctx context.Context, repository string, message []byte) error
-	SubscribeToNotifications(ctx context.Context, repository string) <-chan NotificationMessage
+	SubscribeToNotifications(ctx context.Context, repository string) SubscriberHandle
+	UnsubscribeFromNotifications(ctx context.Context, repository string, handle SubscriberHandle) error
 }
 
 // GetKey returns the key configuration associated with a key ID

--- a/internal/gateway/backend/backend.go
+++ b/internal/gateway/backend/backend.go
@@ -12,10 +12,11 @@ import (
 // Services is a container for the various
 // backend services
 type Services struct {
-	Access AccessConfig
-	Leases LeaseDB
-	Pool   *receiver.Pool
-	Config gw.Config
+	Access        AccessConfig
+	Leases        LeaseDB
+	Pool          *receiver.Pool
+	Notifications *NotificationSystem
+	Config        gw.Config
 }
 
 // ActionController contains the various actions that can be performed with the backend
@@ -58,7 +59,12 @@ func StartBackend(cfg *gw.Config) (*Services, error) {
 		return nil, errors.Wrap(err, "could not start receiver pool")
 	}
 
-	return &Services{Access: *ac, Leases: ldb, Pool: pool, Config: *cfg}, nil
+	ns, err := NewNotificationSystem(cfg.WorkDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not initialize notification system")
+	}
+
+	return &Services{Access: *ac, Leases: ldb, Pool: pool, Notifications: ns, Config: *cfg}, nil
 }
 
 // Stop all the backend services

--- a/internal/gateway/backend/notification_actions.go
+++ b/internal/gateway/backend/notification_actions.go
@@ -12,7 +12,13 @@ func (s *Services) PublishManifest(ctx context.Context, repository string, messa
 	outcome := "success"
 	defer logAction(ctx, "publish_manifest", &outcome, t0)
 
-	return s.Notifications.Publish(ctx, repository, message)
+	err := s.Notifications.Publish(ctx, repository, message)
+
+	if err != nil {
+		outcome = err.Error()
+	}
+
+	return err
 }
 
 // SubscribeToNotifications for a repository
@@ -35,5 +41,11 @@ func (s *Services) UnsubscribeFromNotifications(
 	outcome := "success"
 	defer logAction(ctx, "unsubscribe_from_notifications", &outcome, t0)
 
-	return s.Notifications.Unsubscribe(ctx, repository, handle)
+	err := s.Notifications.Unsubscribe(ctx, repository, handle)
+
+	if err != nil {
+		outcome = err.Error()
+	}
+
+	return err
 }

--- a/internal/gateway/backend/notification_actions.go
+++ b/internal/gateway/backend/notification_actions.go
@@ -4,5 +4,5 @@ import "context"
 
 // PublishManifest publishes a repository manifest to the notification system
 func (s *Services) PublishManifest(ctx context.Context, repository string, message []byte) error {
-	return nil
+	return s.Notifications.Publish(ctx, repository, message)
 }

--- a/internal/gateway/backend/notification_actions.go
+++ b/internal/gateway/backend/notification_actions.go
@@ -1,0 +1,8 @@
+package backend
+
+import "context"
+
+// PublishManifest publishes a repository manifest to the notification system
+func (s *Services) PublishManifest(ctx context.Context, repository string, message []byte) error {
+	return nil
+}

--- a/internal/gateway/backend/notification_actions.go
+++ b/internal/gateway/backend/notification_actions.go
@@ -1,8 +1,28 @@
 package backend
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // PublishManifest publishes a repository manifest to the notification system
 func (s *Services) PublishManifest(ctx context.Context, repository string, message []byte) error {
+	t0 := time.Now()
+
+	outcome := "success"
+	defer logAction(ctx, "publish_manifest", &outcome, t0)
+
 	return s.Notifications.Publish(ctx, repository, message)
+}
+
+// SubscribeToNotifications to activity messages for a repository
+func (s *Services) SubscribeToNotifications(ctx context.Context, repository string) <-chan NotificationMessage {
+	t0 := time.Now()
+
+	outcome := "success"
+	defer logAction(ctx, "subscribe_to_notifications", &outcome, t0)
+
+	source := make(chan NotificationMessage, 1000)
+	s.Notifications.Subscribe(ctx, repository, source)
+	return source
 }

--- a/internal/gateway/backend/notification_actions.go
+++ b/internal/gateway/backend/notification_actions.go
@@ -15,8 +15,8 @@ func (s *Services) PublishManifest(ctx context.Context, repository string, messa
 	return s.Notifications.Publish(ctx, repository, message)
 }
 
-// SubscribeToNotifications to activity messages for a repository
-func (s *Services) SubscribeToNotifications(ctx context.Context, repository string) <-chan NotificationMessage {
+// SubscribeToNotifications for a repository
+func (s *Services) SubscribeToNotifications(ctx context.Context, repository string) SubscriberHandle {
 	t0 := time.Now()
 
 	outcome := "success"
@@ -25,4 +25,15 @@ func (s *Services) SubscribeToNotifications(ctx context.Context, repository stri
 	source := make(chan NotificationMessage, 1000)
 	s.Notifications.Subscribe(ctx, repository, source)
 	return source
+}
+
+// UnsubscribeFromNotifications for a repository
+func (s *Services) UnsubscribeFromNotifications(
+	ctx context.Context, repository string, handle SubscriberHandle) error {
+	t0 := time.Now()
+
+	outcome := "success"
+	defer logAction(ctx, "unsubscribe_from_notifications", &outcome, t0)
+
+	return s.Notifications.Unsubscribe(ctx, repository, handle)
 }

--- a/internal/gateway/backend/notify.go
+++ b/internal/gateway/backend/notify.go
@@ -102,7 +102,7 @@ func (ns *NotificationSystem) Subscribe(
 	ctx context.Context, repository string, handle SubscriberHandle) {
 
 	added := false
-	go func() {
+	func() {
 		ns.SubscriberLock.Lock()
 		defer ns.SubscriberLock.Unlock()
 		subsForRepo, present := ns.Subscribers[repository]

--- a/internal/gateway/backend/notify.go
+++ b/internal/gateway/backend/notify.go
@@ -1,0 +1,63 @@
+package backend
+
+import (
+	"context"
+	"path"
+)
+
+// NotificationMessage is an alias for a UTF-8 string
+type NotificationMessage string
+
+// SubscriberHandle is the writable end of a channel of notification messages
+type SubscriberHandle chan<- NotificationMessage
+
+// SubscriberSet is a set of subscriber handles (implemented as a map handler -> void)
+type SubscriberSet map[SubscriberHandle]struct{}
+
+// SubscriberMap holds a set of subscriber handles for each repository
+type SubscriberMap map[string]SubscriberSet
+
+// NotificationSystem encapsulates the functionality of the repository
+// activity notification system
+type NotificationSystem struct {
+	Subscribers SubscriberMap
+	WorkDir     string
+}
+
+// NewNotificationSystem is a constructor function for the NotificationSystem type
+func NewNotificationSystem(workDir string) (*NotificationSystem, error) {
+	ns := &NotificationSystem{
+		Subscribers: make(SubscriberMap),
+		WorkDir:     path.Join(workDir, "notify"),
+	}
+	return ns, nil
+}
+
+// Publish a new repository manifest to the notification system
+func (ns *NotificationSystem) Publish(
+	ctx context.Context, repository string, message []byte) error {
+	subsForRepo, present := ns.Subscribers[repository]
+	if present {
+		for s := range subsForRepo {
+			s <- NotificationMessage(message)
+		}
+	}
+	return nil
+}
+
+// Subscribe the handle to messages for the given repository
+func (ns *NotificationSystem) Subscribe(
+	ctx context.Context, repository string, handle SubscriberHandle) {
+
+	subsForRepo, present := ns.Subscribers[repository]
+	if present {
+		_, pres := subsForRepo[handle]
+		if !pres {
+			subsForRepo[handle] = struct{}{}
+		}
+	} else {
+		subsForRepo = make(SubscriberSet)
+		subsForRepo[handle] = struct{}{}
+		ns.Subscribers[repository] = subsForRepo
+	}
+}

--- a/internal/gateway/backend/notify.go
+++ b/internal/gateway/backend/notify.go
@@ -145,6 +145,7 @@ func (ns *NotificationSystem) Unsubscribe(
 	}
 
 	delete(subsForRepo, handle)
+	close(handle)
 
 	gw.LogC(ctx, "notify", gw.LogDebug).
 		Str("repository", repository).

--- a/internal/gateway/backend/notify.go
+++ b/internal/gateway/backend/notify.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"path"
 )
 
@@ -9,7 +10,7 @@ import (
 type NotificationMessage string
 
 // SubscriberHandle is the writable end of a channel of notification messages
-type SubscriberHandle chan<- NotificationMessage
+type SubscriberHandle chan NotificationMessage
 
 // SubscriberSet is a set of subscriber handles (implemented as a map handler -> void)
 type SubscriberSet map[SubscriberHandle]struct{}
@@ -60,4 +61,23 @@ func (ns *NotificationSystem) Subscribe(
 		subsForRepo[handle] = struct{}{}
 		ns.Subscribers[repository] = subsForRepo
 	}
+}
+
+// Unsubscribe from messages for the given repository
+func (ns *NotificationSystem) Unsubscribe(
+	ctx context.Context, repository string, handle SubscriberHandle) error {
+
+	subsForRepo, hasSubs := ns.Subscribers[repository]
+	if !hasSubs {
+		return fmt.Errorf("no_subscriptions_for_repository")
+	}
+
+	_, found := subsForRepo[handle]
+	if !found {
+		return fmt.Errorf("invalid_handle")
+	}
+
+	delete(subsForRepo, handle)
+
+	return nil
 }

--- a/internal/gateway/backend/notify_test.go
+++ b/internal/gateway/backend/notify_test.go
@@ -1,0 +1,45 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestNotificationSystem(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "test_notifications")
+	if err != nil {
+		t.Fatalf("could not create temp dir")
+	}
+	defer os.RemoveAll(tmp)
+
+	ns, err := NewNotificationSystem(tmp)
+	if err != nil {
+		t.Fatalf("could not create notification system")
+	}
+
+	hd := make(chan NotificationMessage, 1000)
+
+	ctx := context.TODO()
+	repo := "test.repo.org"
+
+	ns.Subscribe(ctx, repo, hd)
+
+	ns.Publish(ctx, repo, []byte("msg1"))
+	ns.Publish(ctx, repo, []byte("msg2"))
+
+	ns.Unsubscribe(ctx, repo, hd)
+
+	ns.Publish(ctx, repo, []byte("msg3"))
+
+	messages := make([][]byte, 0)
+	for m := range hd {
+		messages = append(messages, []byte(m))
+	}
+
+	if len(messages) != 2 || !bytes.Equal(messages[0], []byte("msg1")) || !bytes.Equal(messages[1], []byte("msg2")) {
+		t.Fatalf("Unexpected received message pattern: %v", messages)
+	}
+}

--- a/internal/gateway/backend/notify_test.go
+++ b/internal/gateway/backend/notify_test.go
@@ -43,3 +43,36 @@ func TestNotificationSystem(t *testing.T) {
 		t.Fatalf("Unexpected received message pattern: %v", messages)
 	}
 }
+
+func TestNotificationSystemLateSubscription(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "test_notifications")
+	if err != nil {
+		t.Fatalf("could not create temp dir")
+	}
+	defer os.RemoveAll(tmp)
+
+	ns, err := NewNotificationSystem(tmp)
+	if err != nil {
+		t.Fatalf("could not create notification system")
+	}
+
+	hd := make(chan NotificationMessage, 1000)
+
+	ctx := context.TODO()
+	repo := "test.repo.org"
+
+	ns.Publish(ctx, repo, []byte("msg1"))
+	ns.Publish(ctx, repo, []byte("msg2"))
+
+	ns.Subscribe(ctx, repo, hd)
+	ns.Unsubscribe(ctx, repo, hd)
+
+	messages := make([][]byte, 0)
+	for m := range hd {
+		messages = append(messages, []byte(m))
+	}
+
+	if len(messages) != 1 || !bytes.Equal(messages[0], []byte("msg2")) {
+		t.Fatalf("Unexpected received message pattern: %v", messages)
+	}
+}

--- a/internal/gateway/frontend/frontend.go
+++ b/internal/gateway/frontend/frontend.go
@@ -51,6 +51,10 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 	// Payloads (new and improved)
 	router.POST(APIRoot+"/payloads/:token", mw(MakePayloadsHandler(services)))
 
+	// Notification system endpoints
+	router.POST(APIRoot+"/notifications/publish", tag(MakeNotificationsHandler(services)))
+	router.GET(APIRoot+"/notifications/subscribe", tag(MakeNotificationsHandler(services)))
+
 	// Admin routes
 	router.POST(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))
 	router.DELETE(APIRoot+"/leases-by-path/*path", amw(MakeAdminLeasesHandler(services)))

--- a/internal/gateway/frontend/notifications.go
+++ b/internal/gateway/frontend/notifications.go
@@ -83,7 +83,6 @@ func handleSubscribe(
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
 
 	gw.LogC(ctx, "http", gw.LogInfo).Msg("event stream starting")
 
@@ -100,10 +99,7 @@ func handleSubscribe(
 		select {
 		case event, ok := <-eventSource:
 			if ok {
-				if _, err := w.Write([]byte("data: " + event + "\n\n")); err != nil {
-					httpWrapError(ctx, err, "could not write event", w, http.StatusInternalServerError)
-					return
-				}
+				w.Write([]byte("data: " + event + "\n\n"))
 				flusher.Flush()
 			} else {
 				break

--- a/internal/gateway/frontend/notifications.go
+++ b/internal/gateway/frontend/notifications.go
@@ -1,0 +1,66 @@
+package frontend
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	gw "github.com/cvmfs/gateway/internal/gateway"
+	be "github.com/cvmfs/gateway/internal/gateway/backend"
+	"github.com/julienschmidt/httprouter"
+)
+
+type reply map[string]interface{}
+
+// MakeNotificationsHandler creates an HTTP handler for the notifications API
+func MakeNotificationsHandler(services be.ActionController) httprouter.Handle {
+	return func(w http.ResponseWriter, h *http.Request, ps httprouter.Params) {
+		if h.Method == "POST" && strings.HasSuffix(h.URL.Path, "publish") {
+			handlePublish(w, h, ps)
+		} else {
+			handleSubscribe(w, h, ps)
+		}
+
+	}
+}
+
+func handlePublish(w http.ResponseWriter, h *http.Request, ps httprouter.Params) {
+	ctx := h.Context()
+
+	var req struct {
+		Version    int             `json:"version"`
+		Timestamp  json.RawMessage `json:"timestamp"`
+		Type       string          `json:"type"`
+		Repository string          `json:"repository"`
+		Manifest   string          `json:"manifest"`
+	}
+
+	var body bytes.Buffer
+	if _, err := io.Copy(&body, h.Body); err != nil {
+		httpWrapError(ctx, err, "could not read request body", w, http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.Unmarshal(body.Bytes(), &req); err != nil {
+		httpWrapError(ctx, err, "invalid request body", w, http.StatusBadRequest)
+		return
+	}
+
+	rep := map[string]interface{}{"status": "ok"}
+
+	gw.LogC(ctx, "http", gw.LogInfo).Msg("request_processed")
+
+	replyJSON(ctx, w, rep)
+}
+
+func handleSubscribe(w http.ResponseWriter, h *http.Request, ps httprouter.Params) {
+	ctx := h.Context()
+
+	rep := make(map[string]interface{})
+
+	gw.LogC(ctx, "http", gw.LogInfo).Msg("request_processed")
+
+	replyJSON(ctx, w, rep)
+}

--- a/internal/gateway/frontend/notifications.go
+++ b/internal/gateway/frontend/notifications.go
@@ -88,6 +88,7 @@ func handleSubscribe(
 	gw.LogC(ctx, "http", gw.LogInfo).Msg("event stream starting")
 
 	eventSource := services.SubscribeToNotifications(ctx, req.Repository)
+	defer services.UnsubscribeFromNotifications(ctx, req.Repository, eventSource)
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		msg := "response writer does not support flushing"

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -94,3 +94,7 @@ func (b *mockBackend) SubmitPayload(ctx context.Context, token string, payload i
 func (b *mockBackend) RunGC(ctx context.Context, options be.GCOptions) (string, error) {
 	return "", nil
 }
+
+func (b *mockBackend) PublishManifest(ctx context.Context, repository string, message []byte) error {
+	return nil
+}

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -99,6 +99,11 @@ func (b *mockBackend) PublishManifest(ctx context.Context, repository string, me
 	return nil
 }
 
-func (b *mockBackend) SubscribeToNotifications(ctx context.Context, repository string) <-chan be.NotificationMessage {
+func (b *mockBackend) SubscribeToNotifications(ctx context.Context, repository string) be.SubscriberHandle {
 	return make(chan be.NotificationMessage)
+}
+
+func (b *mockBackend) UnsubscribeFromNotifications(
+	ctx context.Context, repository string, handle be.SubscriberHandle) error {
+	return nil
 }

--- a/internal/gateway/frontend/testutil.go
+++ b/internal/gateway/frontend/testutil.go
@@ -98,3 +98,7 @@ func (b *mockBackend) RunGC(ctx context.Context, options be.GCOptions) (string, 
 func (b *mockBackend) PublishManifest(ctx context.Context, repository string, message []byte) error {
 	return nil
 }
+
+func (b *mockBackend) SubscribeToNotifications(ctx context.Context, repository string) <-chan be.NotificationMessage {
+	return make(chan be.NotificationMessage)
+}

--- a/tools/test_requests.py
+++ b/tools/test_requests.py
@@ -109,8 +109,20 @@ def publish_manifest(args):
         'repository': args.repo,
         'manifest': manifest
     }
-    rep = requests.post(args.gw_url + "/notifications/publish", json=req)
+    rep = requests.post(args.gw_url + '/notifications/publish', json=req)
     print(json.dumps(rep.json()))
+
+def subscribe(args):
+    req = {
+        'version': 1,
+        'repository': args.repo
+    }
+    rep = requests.get(args.gw_url + '/notifications/subscribe', json=req, stream=True)
+
+    for line in rep.iter_lines():
+        decoded_line = line.decode('utf-8')
+        msg = decoded_line[6:]
+        print(json.dumps(msg))
 
 def main():
     parser = argparse.ArgumentParser(description='Test gateway API requests')
@@ -192,6 +204,11 @@ def main():
     parser_publish_manifest.add_argument('--repo', required=True, help='name of the repository')
     parser_publish_manifest.add_argument('--manifest', required=True, help='URL of the repository manifest')
 
+    parser_subscribe = subparsers.add_parser(
+        'subscribe', help='subscribe to repository notifications'
+    )
+    parser_subscribe.add_argument('--repo', required=True, help="name of the repository")
+
     args = parser.parse_args()
 
     {
@@ -205,7 +222,8 @@ def main():
         'commit_lease': commit_lease,
         'submit_payload': submit_payload,
         'gc': gc,
-        'publish_manifest': publish_manifest
+        'publish_manifest': publish_manifest,
+        'subscribe': subscribe
     }[args.command](args)
 
 

--- a/tools/test_requests.py
+++ b/tools/test_requests.py
@@ -5,6 +5,7 @@ import base64
 import hmac
 import json
 import requests
+import time
 
 # Utility functions
 
@@ -99,6 +100,18 @@ def gc(args):
     rep = requests.post(args.gw_url + '/gc', json=req, headers=headers)
     print(json.dumps(rep.json()))
 
+def publish_manifest(args):
+    manifest = requests.get(args.manifest).text
+    req = {
+        'version': 1,
+        'timestamp': time.strftime('%d %b %Y %H:%M:%S', time.gmtime()),
+        'type': 'activity',
+        'repository': args.repo,
+        'manifest': manifest
+    }
+    rep = requests.post(args.gw_url + "/notifications/publish", json=req)
+    print(json.dumps(rep.json()))
+
 def main():
     parser = argparse.ArgumentParser(description='Test gateway API requests')
     parser.add_argument('--gw_url', required=True,
@@ -173,6 +186,12 @@ def main():
     parser_gc.add_argument('--dry_run', required=False, default=False, action='store_true', help='dry run')
     parser_gc.add_argument('--verbose', required=False, default=False, action='store_true', help='verbose output')
 
+    parser_publish_manifest = subparsers.add_parser(
+        'publish_manifest', help='publish a manifest to the notification system'
+    )
+    parser_publish_manifest.add_argument('--repo', required=True, help='name of the repository')
+    parser_publish_manifest.add_argument('--manifest', required=True, help='URL of the repository manifest')
+
     args = parser.parse_args()
 
     {
@@ -186,6 +205,7 @@ def main():
         'commit_lease': commit_lease,
         'submit_payload': submit_payload,
         'gc': gc,
+        'publish_manifest': publish_manifest
     }[args.command](args)
 
 

--- a/tools/test_requests.py
+++ b/tools/test_requests.py
@@ -107,7 +107,7 @@ def publish_manifest(args):
         'timestamp': time.strftime('%d %b %Y %H:%M:%S', time.gmtime()),
         'type': 'activity',
         'repository': args.repo,
-        'manifest': manifest
+        'manifest': base64.b64encode(manifest.encode('utf-8')).decode('utf-8')
     }
     rep = requests.post(args.gw_url + '/notifications/publish', json=req)
     print(json.dumps(rep.json()))


### PR DESCRIPTION
This add the notification server functionality the gateway application (previously implemented in the separate package `cvmfs-notify`).

Existing functionality has been ported, but the implementation uses server-side events (SSE) instead of Websockets for message delivery. The server part should be used with a matching client based on the server-side events (see: [PR 2383](https://github.com/cvmfs/cvmfs/pull/2383)).