### PR TITLE
Interrupt receiver if we detect an error on push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+build:
+	go build -o cvmfs_gateway
+
+install: build
+	cp cvmfs_gateway /usr/bin/cvmfs_gateway

--- a/internal/gateway/receiver/mock_receiver.go
+++ b/internal/gateway/receiver/mock_receiver.go
@@ -37,3 +37,8 @@ func (r *MockReceiver) SubmitPayload(leasePath string, payload io.Reader, digest
 func (r *MockReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) error {
 	return nil
 }
+
+// Commit command
+func (r *MockReceiver) Interrupt() error {
+	return nil
+}

--- a/internal/gateway/receiver/pool.go
+++ b/internal/gateway/receiver/pool.go
@@ -134,8 +134,9 @@ M:
 			}
 			defer func() {
 				if err := receiver.Quit(); err != nil {
-					task.Reply() <- err
-					return
+					gw.Log("worker_pool", gw.LogInfo).
+						Int("worker_id", workerIdx).
+						Msgf("got an error while quitting: %s", err)
 				}
 			}()
 

--- a/internal/gateway/receiver/receiver.go
+++ b/internal/gateway/receiver/receiver.go
@@ -45,6 +45,8 @@ type Receiver interface {
 	Echo() error
 	SubmitPayload(leasePath string, payload io.Reader, digest string, headerSize int) error
 	Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) error
+	Interrupt() error // like Ctrl-C SIGTERM -2
+	// Kill() error // like Crtl-D SIGKILL -9
 }
 
 // NewReceiver is the factory method for Receiver types
@@ -103,6 +105,9 @@ func NewCvmfsReceiver(ctx context.Context, execPath string) (*CvmfsReceiver, err
 		return nil, errors.Wrap(err, "could not start worker process")
 	}
 
+	workerInRead.Close()
+	workerOutWrite.Close()
+
 	gw.LogC(ctx, "receiver", gw.LogDebug).
 		Str("command", "start").
 		Msg("worker process ready")
@@ -114,9 +119,13 @@ func NewCvmfsReceiver(ctx context.Context, execPath string) (*CvmfsReceiver, err
 
 // Quit command is sent to the worker
 func (r *CvmfsReceiver) Quit() error {
+	needToWait := true
 	defer func() {
 		r.workerCmdIn.Close()
 		r.workerCmdOut.Close()
+		if needToWait {
+			r.worker.Wait()
+		}
 	}()
 
 	if _, err := r.call(receiverQuit, []byte{}, nil); err != nil {
@@ -139,7 +148,9 @@ func (r *CvmfsReceiver) Quit() error {
 		Str("pipe", "stdout").
 		Msg(string(buf2))
 
-	if err := r.worker.Wait(); err != nil {
+	err := r.worker.Wait()
+	needToWait = false
+	if err != nil {
 		return errors.Wrap(err, "waiting for worker process failed")
 	}
 
@@ -219,6 +230,10 @@ func (r *CvmfsReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag g
 	return result
 }
 
+func (r *CvmfsReceiver) Interrupt() error {
+	return r.worker.Process.Signal(os.Interrupt)
+}
+
 func (r *CvmfsReceiver) call(reqID receiverOp, msg []byte, payload io.Reader) ([]byte, error) {
 	if err := r.request(reqID, msg, payload); err != nil {
 		return nil, err
@@ -237,6 +252,7 @@ func (r *CvmfsReceiver) request(reqID receiverOp, msg []byte, payload io.Reader)
 	}
 	if payload != nil {
 		if _, err := io.Copy(r.workerCmdIn, payload); err != nil {
+			r.Interrupt()
 			return errors.Wrap(err, "could not write request payload")
 		}
 	}


### PR DESCRIPTION
The gateway is plagued with a complex bug.

In normal operations files are read from the filesystem, serialized into object pack, and ship to the gateway. The gateway forward this object pack to the receiver that add them to the storage.

Unpack run a more complex pipeline. Files are ingested from a streamed tarball. The tarball is not present in the filesystem, but comes directly from the network and it is piped into cvmfs. For any reason, it might happen that the publisher (the cvmfs part that send data to the gateway) stop working.
It could crash for internal bug, it could run out of memory, or it could find a truncated tar file.

If the publisher crash while the receiver is already running we run into a problem.
The receiver will be waiting for the rest of the object pack, that it will never came because the publisher crashed. The receiver will keep running in an infinite loop waiting for more data that will never come. In this state, the particular receiver cannot serve more request, blocking completely the gateway machine, and not only for a single repository.

The gateway is able to detect this problem, the stream between publisher and gateway is been broken since the publisher exited.
Once the gateway detect the problem it need a way to stop the receiver.
The receiver is busy waiting for the rest of the stream.

Different options where possible.
1. Send a escape sequence to block the receiver, but how to distinguish an escaped sequence from correct data?
2. Insert a timeout, but how long?
3. Send a signal to the receiver.

In this PR we opted for 3.

The receiver could also listen for SIGTERM and decide to clean up the file it added, without creating dark garbage.

Inserting a quite long timeout (maybe 10 minutes?) in the receiver seems like a good idea nevertheless.

Unfortunately I was not able to create a reproducible test case. I debugged this problem Ctrl-C the process when it makes sense.

With the fix in place I wasn't able to reproduce the problem anymore, but I could see that the receiver was killed and that the gateway was logging the problem being detected.