### PR TITLE
Set number of file descriptors to 131072

### DIFF
--- a/pkg/cvmfs-gateway.service
+++ b/pkg/cvmfs-gateway.service
@@ -9,6 +9,7 @@ StandardOutput=journal
 Restart=always
 RestartSec=5
 User=root
+LimitNOFILE=131072
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/cvmfs-gateway@.service
+++ b/pkg/cvmfs-gateway@.service
@@ -9,6 +9,7 @@ StandardOutput=journal
 Restart=always
 RestartSec=5
 User=%I
+LimitNOFILE=131072
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
For the cvmfs-gateway systemd unit, set the number of maximum file descriptor to 131072.
This is applied to both cvmfs-gateway service files in `/pkg` folder.